### PR TITLE
Generate the local repoName

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -27,7 +27,7 @@ func start(opts *Options, repoUrl string) {
 	if err != nil {
 		log.Fatalf("failed to clone repo %v", err)
 	}
-	repoName := strings.Split(repoUrl, "/")[4]
+	repoName := getLocalRepoName(repoUrl)
 	if err := os.Chdir(repoName); err != nil {
 		log.Fatal(err)
 	}
@@ -41,6 +41,17 @@ func start(opts *Options, repoUrl string) {
 	cleanup(repoName)
 	reportJson, _ := json.MarshalIndent(report, "", "\t")
 	err = ioutil.WriteFile(fmt.Sprintf("%s_leaks.json", repoName), reportJson, 0644)
+}
+
+// getLocalRepoName generates the name of the local clone folder based on the given URL
+func getLocalRepoName(url string) string {
+	splitSlashes := strings.Split(url, "/")
+	name := splitSlashes[len(splitSlashes)-1]
+	name = strings.TrimSuffix(name, ".git")
+	splitColons := strings.Split(name, ":")
+	name = splitColons[len(splitColons)-1]
+
+	return name
 }
 
 func cleanup(repoName string) {

--- a/leaks_test.go
+++ b/leaks_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestGetLocalRepoName(t *testing.T) {
+	cases := []struct{
+		name string
+		input string
+		expected string
+	}{
+		{
+			"Usual github url",
+			"https://github.com/usual/url",
+			"url",
+		},
+		{
+			"Usual github url with .git suffix",
+			"https://github.com/usual/url.git",
+			"url",
+		},
+		{
+			"personal git url",
+			"git@github.com:url.git",
+			"url",
+		},
+		{
+			"personal git url in sub folder",
+			"git@github.com:sub/url.git",
+			"url",
+		},
+		{
+			"ssh git url with port",
+			"ssh://git@github.com:2222/sub/url.git",
+			"url",
+		},
+		{
+			"local git in sub folder",
+			"local/url.git",
+			"url",
+		},
+		{
+			"local git in same folder",
+			"url.git",
+			"url",
+		},
+	}
+
+	for _, c := range cases {
+		actual := getLocalRepoName(c.input)
+		if actual != c.expected {
+			t.Errorf("'%s' failed. Input: '%s'; Expected: '%s'; Got: '%s'", c.input, c.name, c.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
To support other URLs than standard github URLs, the repoName
is now being generated based on the given URL.

Currently supported are formats for HTTP, SSH and local paths.

Fixes #4