### PR TITLE
Use GOs flag package for command line parsing

### DIFF
--- a/leaks.go
+++ b/leaks.go
@@ -21,18 +21,18 @@ type LeakElem struct {
 }
 
 // start clones and determines if there are any leaks
-func start(opts *Options) {
+func start(repoURL string) {
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
-	fmt.Printf("Cloning \x1b[37;1m%s\x1b[0m...\n", opts.RepoURL)
-	err := exec.Command("git", "clone", opts.RepoURL).Run()
+	fmt.Printf("Cloning \x1b[37;1m%s\x1b[0m...\n", repoURL)
+	err := exec.Command("git", "clone", repoURL).Run()
 	if err != nil {
 		log.Printf("failed to clone repo %v", err)
 		return
 	}
-	fmt.Printf("Evaluating \x1b[37;1m%s\x1b[0m...\n", opts.RepoURL)
-	repoName := getLocalRepoName(opts.RepoURL)
+	fmt.Printf("Evaluating \x1b[37;1m%s\x1b[0m...\n", repoURL)
+	repoName := getLocalRepoName(repoURL)
 	if err = os.Chdir(repoName); err != nil {
 		log.Fatal(err)
 	}
@@ -42,9 +42,9 @@ func start(opts *Options) {
 		os.Exit(1)
 	}()
 
-	report := getLeaks(repoName, opts)
+	report := getLeaks(repoName)
 	if len(report) == 0 {
-		fmt.Printf("No Leaks detected for \x1b[35;2m%s\x1b[0m...\n\n", opts.RepoURL)
+		fmt.Printf("No Leaks detected for \x1b[35;2m%s\x1b[0m...\n\n", repoURL)
 	}
 	cleanup(repoName)
 	reportJSON, _ := json.MarshalIndent(report, "", "\t")
@@ -77,7 +77,7 @@ func cleanup(repoName string) {
 }
 
 // getLeaks will attempt to find gitleaks
-func getLeaks(repoName string, opts *Options) []LeakElem {
+func getLeaks(repoName string) []LeakElem {
 	var (
 		out               []byte
 		err               error
@@ -86,7 +86,7 @@ func getLeaks(repoName string, opts *Options) []LeakElem {
 		gitLeaks          = make(chan LeakElem)
 		report            []LeakElem
 	)
-	semaphoreChan := make(chan struct{}, opts.Concurrency)
+	semaphoreChan := make(chan struct{}, *concurrency)
 
 	go func(commitWG *sync.WaitGroup, gitLeakReceiverWG *sync.WaitGroup) {
 		for gitLeak := range gitLeaks {
@@ -107,7 +107,7 @@ func getLeaks(repoName string, opts *Options) []LeakElem {
 		currCommit := string(currCommitB)
 
 		go func(currCommit string, repoName string, commitWG *sync.WaitGroup,
-			gitLeakReceiverWG *sync.WaitGroup, opts *Options) {
+			gitLeakReceiverWG *sync.WaitGroup) {
 
 			defer commitWG.Done()
 			var leakPrs bool
@@ -137,16 +137,16 @@ func getLeaks(repoName string, opts *Options) []LeakElem {
 			}
 
 			for _, line := range lines {
-				leakPrs = checkShannonEntropy(line, opts.B64EntropyCutoff, opts.HexEntropyCutoff)
+				leakPrs = checkShannonEntropy(line, *b64EntropyCutoff, *hexEntropyCutoff)
 				if leakPrs {
-					if opts.Strict && containsStopWords(line) {
+					if *strict && containsStopWords(line) {
 						continue
 					}
 					gitLeakReceiverWG.Add(1)
 					gitLeaks <- LeakElem{line, currCommit}
 				}
 			}
-		}(currCommit, repoName, &commitWG, &gitLeakReceiverWG, opts)
+		}(currCommit, repoName, &commitWG, &gitLeakReceiverWG)
 	}
 
 	commitWG.Wait()

--- a/main.go
+++ b/main.go
@@ -44,15 +44,15 @@ func init() {
 }
 
 func main() {
-	args := os.Args[1:]
-	opts := parseOptions(args)
-	if opts.RepoURL != "" {
-		start(opts)
-	} else if opts.UserURL != "" || opts.OrgURL != "" {
-		repoList := repoScan(opts)
+	//args := os.Args[1:]
+	//opts := parseOptions(args)
+	parseOptions()
+	if *repoURL != "" {
+		start(*repoURL)
+	} else if *userURL != "" || *orgURL != "" {
+		repoList := repoScan()
 		for _, repo := range repoList {
-			opts.RepoURL = repo.RepoURL
-			start(opts)
+			start(repo.RepoURL)
 		}
 	}
 }
@@ -63,7 +63,7 @@ type RepoElem struct {
 }
 
 // repoScan attempts to parse all repo urls from an organization or user
-func repoScan(opts *Options) []RepoElem {
+func repoScan() []RepoElem {
 	var (
 		targetURL  string
 		target     string
@@ -71,11 +71,11 @@ func repoScan(opts *Options) []RepoElem {
 		repoList   []RepoElem
 	)
 
-	if opts.UserURL != "" {
-		targetURL = opts.UserURL
+	if *userURL != "" {
+		targetURL = *userURL
 		targetType = "users"
 	} else {
-		targetURL = opts.OrgURL
+		targetURL = *orgURL
 		targetType = "orgs"
 	}
 	splitTargetURL := strings.Split(targetURL, "/")

--- a/options.go
+++ b/options.go
@@ -1,111 +1,28 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"strconv"
+	"log"
+	"flag"
 )
 
-// TODO regex on type.. user/organization can be treated as the same:
-// 	hittps://github.com/<user or org>
-// 	hittps://github.com/<user or org>/repo
-const usage = `usage: gitleaks [git link] [options]
+var (
+	concurrency      = flag.Int("c", 10, "Concurrency factor (potential number of git files open)")
+	b64EntropyCutoff = flag.Int("e", 70, "Base64 entropy cutoff")
+	hexEntropyCutoff = flag.Int("x", 40, "Hex entropy cutoff")
+	userURL          = flag.String("u", "", "Git user URL")
+	repoURL          = flag.String("r", "", "Git repo URL")
+	orgURL           = flag.String("o", "", "Git organization URL")
+	strict           = flag.Bool("s", false, "Strict mode uses stopwords in checks.go")
+)
 
-Options:
-	-c 			Concurrency factor (potential number of git files open)
-	-u 		 	Git user url
-	-r 			Git repo url
-	-o 			Git organization url
-	-s 			Strict mode uses stopwords in checks.go
-	-e 			Base64 entropy cutoff, default is 70
-	-x 			Hex entropy cutoff, default is 40
-	-h --help 		Display this message
-`
+func parseOptions() {
+	flag.Parse()
 
-// Options for gitleaks
-type Options struct {
-	Concurrency      int
-	B64EntropyCutoff int
-	HexEntropyCutoff int
-	UserURL          string
-	OrgURL           string
-	RepoURL          string
-	Strict           bool
-}
-
-// help prints the usage string and exits
-func help() {
-	os.Stderr.WriteString(usage)
-	os.Exit(1)
-}
-
-// optionsNextInt is a parseOptions helper that returns the value (int) of an option
-// if valid.
-func optionsNextInt(args []string, i *int) int {
-	if len(args) > *i+1 {
-		*i++
-	} else {
-		help()
-	}
-	argInt, err := strconv.Atoi(args[*i])
-	if err != nil {
-		fmt.Printf("Invalid %s option: %s\n", args[*i-1], args[*i])
-		help()
-	}
-	return argInt
-}
-
-// optionsNextString is a parseOptions helper that returns the value (string) of an option
-// if valid.
-func optionsNextString(args []string, i *int) string {
-	if len(args) > *i+1 {
-		*i++
-	} else {
-		fmt.Printf("Invalid %s option: %s\n", args[*i-1], args[*i])
-		help()
-	}
-	return args[*i]
-}
-
-// parseOptions
-func parseOptions(args []string) *Options {
-	opts := &Options{
-		Concurrency:      10,
-		B64EntropyCutoff: 70,
-		HexEntropyCutoff: 40,
+	if *concurrency < 1 {
+		*concurrency = 1
 	}
 
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		switch arg {
-		case "-s":
-			opts.Strict = true
-		case "-e":
-			opts.B64EntropyCutoff = optionsNextInt(args, &i)
-		case "-x":
-			opts.HexEntropyCutoff = optionsNextInt(args, &i)
-		case "-c":
-			opts.Concurrency = optionsNextInt(args, &i)
-		case "-o":
-			opts.OrgURL = optionsNextString(args, &i)
-		case "-u":
-			opts.UserURL = optionsNextString(args, &i)
-		case "-r":
-			opts.RepoURL = optionsNextString(args, &i)
-		case "-h", "--help":
-			help()
-			return nil
-		default:
-			if i == len(args)-1 && opts.OrgURL == "" && opts.RepoURL == "" &&
-				opts.UserURL == "" {
-				opts.RepoURL = arg
-			} else {
-				fmt.Printf("Uknown option %s\n\n", arg)
-				help()
-				return nil
-			}
-		}
+	if *userURL == "" && *repoURL == "" && *orgURL == "" {
+		log.Fatal("No repository specified")
 	}
-
-	return opts
 }


### PR DESCRIPTION
Changed the command line parser to use the [flag](https://golang.org/pkg/flag/) package already in go included, makes the code more readable and expandable in my opinion. The -h --help flags are added automatically. Maybe even add the contents of options.go to main.go? 

Happy to hear what you think!