### PR TITLE
Added pagination for users and orgs that have more than 30 repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options:
 	-s 			Strict mode uses stopwords in checks.go
 	-e 			Base64 entropy cutoff, default is 70
 	-x 			Hex entropy cutoff, default is 40
+	-t 			GitHub OAuth Token
 	-h --help 		Display this message
 ```
 NOTE: your mileage may vary so if you aren't getting the results you expected try tweaking the entropy cutoffs and stopwords. Entropy cutoff for base64 alphabets seemed to give good results around 70 and hex alphabets seemed to give good results around 40. Entropy is calculated using http://www.bearcave.com/misl/misl_tech/wavelets/compression/shannon.html

--- a/leaks.go
+++ b/leaks.go
@@ -1,3 +1,4 @@
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -117,6 +117,9 @@ func repoScan(opts *Options) []RepoElem {
 
 func getMaxPages(linkHeader string) int {
 	links := strings.Split(linkHeader, ",")
+	if len(links) == 1 {
+		return 1
+	}
 
 	re_last := regexp.MustCompile(`rel="last"`)
 	re_page := regexp.MustCompile(`[?&]page=(\d+)`)

--- a/options.go
+++ b/options.go
@@ -19,6 +19,7 @@ Options:
 	-s 			Strict mode uses stopwords in checks.go
 	-e 			Base64 entropy cutoff, default is 70
 	-x 			Hex entropy cutoff, default is 40
+	-t 			GitHub OAuth Token
 	-h --help 		Display this message
 `
 
@@ -30,6 +31,7 @@ type Options struct {
 	UserURL          string
 	OrgURL           string
 	RepoURL          string
+	Token			 string
 	Strict           bool
 }
 
@@ -92,6 +94,8 @@ func parseOptions(args []string) *Options {
 			opts.UserURL = optionsNextString(args, &i)
 		case "-r":
 			opts.RepoURL = optionsNextString(args, &i)
+		case "-t":
+			opts.Token = optionsNextString(args, &i)
 		case "-h", "--help":
 			help()
 			return nil


### PR DESCRIPTION
By default the GitHub API only returns 30 entries, so we need to paginate the results to correctly gather all available repositories. This is a quick fix to accomplish this. Another option would be to use the github-go package. Also added the option to specify an oauth token to increase the ratelimit.