### PR TITLE
#35 Add GCP service account key check: PKCS8

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func init() {
 		"Info", "INFO", "env", "Env", "ENV", "environment", "Environment", "ENVIRONMENT"}
 
 	regexes = map[string]*regexp.Regexp{
+		"PKCS8":    regexp.MustCompile("-----BEGIN PRIVATE KEY-----"),
 		"RSA":      regexp.MustCompile("-----BEGIN RSA PRIVATE KEY-----"),
 		"SSH":      regexp.MustCompile("-----BEGIN OPENSSH PRIVATE KEY-----"),
 		"Facebook": regexp.MustCompile("(?i)facebook.*['|\"][0-9a-f]{32}['|\"]"),


### PR DESCRIPTION
Example GPC key:
```
{
  ***
  "private_key": "-----BEGIN PRIVATE KEY----- ***"
  ***
}
```

I saw some people commit it to repo.