### PR TITLE
Simplify the stopwords check

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -90,7 +90,7 @@ func checkShannonEntropy(target string) bool {
 // containsStopWords checks if there are any stop words in target
 func containsStopWords(target string) bool {
 	for _, stopWord := range stopWords {
-		if strings.Contains(target, stopWord) {
+		if strings.EqualFold(target, stopWord) {
 			return true
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -37,8 +37,7 @@ func init() {
 	base64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
 	hexChars = "1234567890abcdefABCDEF"
 
-	stopWords = []string{"setting", "Setting", "SETTING", "info",
-		"Info", "INFO", "env", "Env", "ENV", "environment", "Environment", "ENVIRONMENT"}
+	stopWords = []string{"setting", "info",	"env", "environment"}
 
 	regexes = map[string]*regexp.Regexp{
 		"RSA":      regexp.MustCompile("-----BEGIN RSA PRIVATE KEY-----"),


### PR DESCRIPTION
Change to strings.EqualFold for a case insensitive search of stopwords.