### PR TITLE
Make stopwords lowercase

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -89,6 +89,9 @@ func checkShannonEntropy(target string) bool {
 
 // containsStopWords checks if there are any stop words in target
 func containsStopWords(target string) bool {
+	// Convert to lowercase to reduce the number of loops needed.
+	target = strings.ToLower(target)
+	
 	for _, stopWord := range stopWords {
 		if strings.Contains(target, stopWord) {
 			return true

--- a/main.go
+++ b/main.go
@@ -37,8 +37,7 @@ func init() {
 	base64Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
 	hexChars = "1234567890abcdefABCDEF"
 
-	stopWords = []string{"setting", "Setting", "SETTING", "info",
-		"Info", "INFO", "env", "Env", "ENV", "environment", "Environment", "ENVIRONMENT"}
+	stopWords = []string{"setting", "info", "env", "environment"}
 
 	regexes = map[string]*regexp.Regexp{
 		"PKCS8":    regexp.MustCompile("-----BEGIN PRIVATE KEY-----"),


### PR DESCRIPTION
By using strings.ToLower we can reduce the number of times we need to loop in the stopwords check.