### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,11 @@
 FROM golang:1.10.0 AS build
-
-ENV PROJECT /go/src/github.com/zricethezav/gitleaks
-
-RUN mkdir -p $PROJECT
-
-WORKDIR ${PROJECT}
-
-RUN git clone https://github.com/zricethezav/gitleaks.git . \
-  && CGO_ENABLED=0 go build -o bin/gitleaks *.go
+WORKDIR /go/src/github.com/zricethezav/gitleaks
+COPY . .
+RUN CGO_ENABLED=0 go build -o bin/gitleaks *.go
 
 FROM alpine:3.7
-
-ENV PROJECT /go/src/github.com/zricethezav/gitleaks
-
-WORKDIR /app
-
-RUN apk update && apk upgrade && apk add --no-cache bash git openssh
-
-COPY --from=build $PROJECT/bin/* /usr/bin/
-
+RUN apk add --no-cache bash git openssh
+COPY --from=build /go/src/github.com/zricethezav/gitleaks/bin/* /usr/bin/
 ENTRYPOINT ["gitleaks"]
 
 # How to use me :


### PR DESCRIPTION
Simplified Dockerfile.
Here's what changed and why:

- No need for `RUN mkdir -p $PROJECT` because `WORKDIR` automatically creates directories if they don't exist.
- No need to `RUN git clone https://github.com/zricethezav/gitleaks.git . ` since we're building the container image locally and we have the project files available locally. Therefore, no need to reach out to the internet to re-download it.
  - just `COPY` all local files into the current working directory (which is `/go/src/.../.../gitleaks`) in the container.
- No need to `RUN apk update && apk upgrade && apk add --no-cache bash git openssh`, because `apk update` and `apk upgrade` cache files locally in the container, thus leading to bloated image size.
  - Just simply do `apk add --no-cache ...` to install dependencies without writing any cache locally. This is equivalent to `apk update && apk upgrade && apk add ... && rm -rf /var/logs/apk/cache/*`
- Removed `WORKDIR /app` as there is no need for it. The compiled binary is placed in `/usr/bin/`.