### PR TITLE
Fix commit option

### DIFF
--- a/gitleaks_test.go
+++ b/gitleaks_test.go
@@ -560,6 +560,14 @@ func TestAuditRepo(t *testing.T) {
 			numLeaks:    0,
 			configPath:  path.Join(configsDir, "repo"),
 		},
+		{
+			repo:        leaksRepo,
+			description: "Audit until specific commit",
+			numLeaks:    1,
+			testOpts: Options{
+				Commit: "f6839959b7bbdcd23008f1fb16f797f35bcd3a0c",
+			},
+		},
 	}
 
 	whiteListCommits = make(map[string]bool)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -450,6 +451,7 @@ func auditGitReference(repo *RepoDescriptor, ref *plumbing.Reference) []Leak {
 	err = cIter.ForEach(func(c *object.Commit) error {
 		if c.Hash.String() == opts.Commit {
 			cIter.Close()
+			return errors.New("ErrStop")
 		}
 		if whiteListCommits[c.Hash.String()] {
 			log.Infof("skipping commit: %s\n", c.Hash.String())


### PR DESCRIPTION
The --commit option was being ignored because the `Close()` function doesn't stop
the iterator.
According to the documentation:
https://godoc.org/gopkg.in/src-d/go-git.v4/plumbing/object#FileIter.ForEach
an `ErrStop` error should be send to stop it.

I'm not sure what the what the `Close()` function actually does and  maybe that can be removed.