### PR TITLE
Validate --report option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+1.11.2
+----
+- Validate report option
 1.11.1
 ----
 - fix commit whitelist logic

--- a/gitleaks_test.go
+++ b/gitleaks_test.go
@@ -722,6 +722,22 @@ func TestOptionGuard(t *testing.T) {
 			description:    "Invalid entropy level guard",
 			expectedErrMsg: "The maximum level of entropy is 8",
 		},
+		{
+			testOpts: Options{
+				GithubOrg: "fakeOrg",
+				Report:    "/tmp",
+			},
+			description:    "Report not pointing to a .json file",
+			expectedErrMsg: "Report should be a .json file",
+		},
+		{
+			testOpts: Options{
+				GithubOrg: "fakeOrg",
+				Report:    "/fake/foo.json",
+			},
+			description:    "Report pointing to a directory that does not exist",
+			expectedErrMsg: "/fake does not exist",
+		},
 	}
 	g := goblin.Goblin(t)
 	for _, test := range tests {

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ type gitDiff struct {
 }
 
 const defaultGithubURL = "https://api.github.com/"
-const version = "1.11.1"
+const version = "1.11.2"
 const errExit = 2
 const leakExit = 1
 const defaultConfig = `
@@ -925,6 +925,17 @@ func optsGuard() error {
 
 	if opts.Entropy > 8 {
 		return fmt.Errorf("The maximum level of entropy is 8")
+	}
+
+	if opts.Report != "" {
+		if !strings.HasSuffix(opts.Report, ".json") {
+			return fmt.Errorf("Report should be a .json file")
+		}
+
+		dirPath := filepath.Dir(opts.Report)
+		if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+			return fmt.Errorf("%s does not exist", dirPath)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I found the need for this the hard way haha.
I was using the tool on a large repo and I set the `--report`option to a directory instead of a file so when the execution finished, I had no report :(