### PR TITLE
fix slack token format

### DIFF
--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -28,7 +28,7 @@ description = "PGP"
 regex = '''-----BEGIN PGP PRIVATE KEY BLOCK-----'''
 [[regexes]]
 description = "Slack token"
-regex = '''xoxo[bapr]-.*'''
+regex = '''xox[baprs]-.*'''
 
 [whitelist]
 regexes = [

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ description = "Github"
 regex = '''(?i)github.*['\"][0-9a-zA-Z]{35,40}['\"]'''
 [[regexes]]
 description = "Slack"
-regex = '''xoxo[bapr]-.*'''
+regex = '''xox[baprs]-.*'''
 [[regexes]]
 description = "Telegram"
 regex = '''\d{5,}:A[a-zA-Z0-9_\-]{34,34}'''


### PR DESCRIPTION
This fixes the Slack token format. I'm not sure if there was a time when `xoxo[bapr]` was the correct regex, but per https://api.slack.com/docs/token-types , the 2nd `o` doesn't occur in their tokens. This PR additionally adds coverage for `xoxs`, which is the prefix for Slack official client session tokens.