### PR TITLE
Remove break lines in commit messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -523,7 +523,7 @@ func auditGitReference(repo *RepoDescriptor, ref *plumbing.Reference) []Leak {
 								content:  chunk.Content(),
 								sha:      c.Hash.String(),
 								author:   c.Author.String(),
-								message:  c.Message,
+								message:  strings.Replace(c.Message, "\n", " ", -1),
 								date:     c.Author.When,
 							}
 							chunkLeaks := inspect(diff)


### PR DESCRIPTION
Breaklines in a csv report caused issues when importing the data to an
spreadsheet application like LibreOffice Calc or Microsoft Excel.