### PR TITLE
Fix files whitelisting when checking Github PRs

### DIFF
--- a/gitleaks_test.go
+++ b/gitleaks_test.go
@@ -176,6 +176,7 @@ func TestRun(t *testing.T) {
 		description    string
 		expectedErrMsg string
 		whiteListRepos []string
+		whiteListFiles []*regexp.Regexp
 		numLeaks       int
 		configPath     string
 		commitPerPage  int
@@ -290,6 +291,18 @@ func TestRun(t *testing.T) {
 			expectedErrMsg: "",
 			commitPerPage:  1,
 		},
+		{
+			testOpts: Options{
+				GithubPR: "https://github.com/gitleakstest/gronit/pull/1",
+			},
+			description:    "test github pr with whitelisted files",
+			numLeaks:       0,
+			expectedErrMsg: "",
+			commitPerPage:  1,
+			whiteListFiles: []*regexp.Regexp{
+				regexp.MustCompile("main.go"),
+			},
+		},
 	}
 	g := goblin.Goblin(t)
 	for _, test := range tests {
@@ -300,6 +313,11 @@ func TestRun(t *testing.T) {
 				}
 				if test.commitPerPage != 0 {
 					githubPages = test.commitPerPage
+				}
+				if test.whiteListFiles != nil {
+					whiteListFiles = test.whiteListFiles
+				} else {
+					whiteListFiles = nil
 				}
 				opts = test.testOpts
 				leaks, err := run()

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
 
 [whitelist]
 files = [
-  "(.*?)(jpg|gif|doc|pdf|bin)$" 
+  "(.*?)(jpg|gif|doc|pdf|bin)$"
 ]
 #commits = [
 #  "BADHA5H1",
@@ -486,11 +486,6 @@ func auditGitReference(repo *RepoDescriptor, ref *plumbing.Reference) []Leak {
 				if bin || err != nil {
 					return nil
 				}
-				for _, re := range whiteListFiles {
-					if re.FindString(f.Name) != "" {
-						return nil
-					}
-				}
 				content, err := f.Contents()
 				if err != nil {
 					return nil
@@ -558,12 +553,6 @@ func auditGitReference(repo *RepoDescriptor, ref *plumbing.Reference) []Leak {
 					} else if to != nil {
 						filePath = to.Path()
 					}
-					for _, re := range whiteListFiles {
-						if re.FindString(filePath) != "" {
-							skipFile = true
-							break
-						}
-					}
 					if skipFile {
 						continue
 					}
@@ -602,11 +591,18 @@ func auditGitReference(repo *RepoDescriptor, ref *plumbing.Reference) []Leak {
 // will skip lines that include a whitelisted regex. A list of leaks is returned.
 // If verbose mode (-v/--verbose) is set, then checkDiff will log leaks as they are discovered.
 func inspect(diff gitDiff) []Leak {
-	lines := strings.Split(diff.content, "\n")
 	var (
 		leaks    []Leak
 		skipLine bool
 	)
+
+	for _, re := range whiteListFiles {
+		if re.FindString(diff.filePath) != "" {
+			return leaks
+		}
+	}
+
+	lines := strings.Split(diff.content, "\n")
 
 	for _, line := range lines {
 		skipLine = false


### PR DESCRIPTION
Files whitelisting code was not executed when running the tool against a
Github PR so the config was ignored.

To avoid duplication, the whitelist files check has been moved to the `inspect`
function which is always executed.