### PR TITLE
Fix error handling in clone operation, plus some trivial changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,11 +128,12 @@ type entropyRange struct {
 	v2 float64
 }
 
-const defaultGithubURL = "https://api.github.com/"
-const version = "1.20.0"
-const errExit = 2
-const leakExit = 1
-const defaultConfig = `
+const (
+	defaultGithubURL = "https://api.github.com/"
+	version          = "1.20.0"
+	errExit          = 2
+	leakExit         = 1
+	defaultConfig    = `
 # This is a sample config file for gitleaks. You can configure gitleaks what to search for and what to whitelist.
 # The output you are seeing here is the default gitleaks config. If GITLEAKS_CONFIG environment variable
 # is set, gitleaks will load configurations from that path. If option --config-path is set, gitleaks will load
@@ -185,6 +186,7 @@ files = [
 #	"6.0-8.0
 #]
 `
+)
 
 var (
 	opts              Options

--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
 
 [whitelist]
 files = [
-  "(.*?)(jpg|gif|doc|pdf|bin)$" 
+  "(.*?)(jpg|gif|doc|pdf|bin)$"
 ]
 #commits = [
 #  "BADHA5H1",

--- a/main.go
+++ b/main.go
@@ -379,6 +379,9 @@ func cloneRepo() (*RepoDescriptor, error) {
 	} else if opts.RepoPath != "" {
 		log.Infof("opening %s", opts.RepoPath)
 		repo, err = git.PlainOpen(opts.RepoPath)
+		if err != nil {
+			return nil, fmt.Errorf("error opening repo: %v", err)
+		}
 	} else {
 		log.Infof("cloning %s", opts.Repo)
 		if strings.HasPrefix(opts.Repo, "git") {

--- a/main.go
+++ b/main.go
@@ -247,9 +247,11 @@ func main() {
 		log.Error(err)
 		os.Exit(errExit)
 	}
+
 	if opts.Report != "" {
 		writeReport(leaks)
 	}
+
 	if len(leaks) != 0 {
 		log.Warnf("%d leaks detected. %d commits inspected in %s", len(leaks), totalCommits, durafmt.Parse(time.Now().Sub(now)).String())
 		os.Exit(leakExit)

--- a/main.go
+++ b/main.go
@@ -54,7 +54,6 @@ type RepoDescriptor struct {
 	url        string
 	name       string
 	repository *git.Repository
-	err        error
 }
 
 // Options for gitleaks
@@ -391,12 +390,15 @@ func cloneRepo() (*RepoDescriptor, error) {
 			})
 		}
 	}
+	if err != nil {
+		return nil, fmt.Errorf("error cloning repo: %v", err)
+	}
+
 	return &RepoDescriptor{
 		repository: repo,
 		path:       opts.RepoPath,
 		url:        opts.Repo,
 		name:       filepath.Base(opts.Repo),
-		err:        err,
 	}, nil
 }
 


### PR DESCRIPTION
gitleaks does not check the error path when cloning a repo properly, and consequently, a panic is raised with a segmentation fault. This pull requests fixes the error handling.

For example, if we try to open a non-existent repo in current working directory:
```
$ gitleaks -v --repo-path=foo-bar
INFO[2018-11-14T14:36:02+01:00] opening foo-bar
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15630e9]
```
With the new changes it returns an error message:
```
$ gitleaks -v --repo-path=foo-bar
INFO[2018-11-14T14:40:31+01:00] opening foo-bar
ERRO[2018-11-14T14:40:31+01:00] error cloning repo: repository does not exist
```

Another example, if we specify are remote repository that does not exist, it does not report anything back:
```
$ gitleaks -v -r /dev/code
INFO[2018-11-14T14:37:36+01:00] cloning /dev/code
INFO[2018-11-14T14:37:36+01:00] 0 leaks detected. 0 commits inspected in 23 milliseconds
```

With the new change, it returns a message:
```
$ gitleaks -v -r /dev/code
INFO[2018-11-14T14:42:04+01:00] cloning /dev/code
ERRO[2018-11-14T14:42:04+01:00] error cloning repo: repository not found
```
I find the "error cloning repo" message followed by the error, more descriptive than a plain "authentication required" error message.

The pull request also includes some trivial code convention fixes.