### PR TITLE
Add support for tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+1.21.0
+----
+- added support for cloning repositories using github api
+
 1.20.0
 ----
 - adding gitlab user and group support

--- a/github.go
+++ b/github.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	git "gopkg.in/src-d/go-git.v4"
+	gitHttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 )
 
@@ -177,6 +178,7 @@ func cloneGithubRepo(githubRepo *github.Repository) (*RepoDescriptor, error) {
 		repo *git.Repository
 		err  error
 	)
+	githubToken := os.Getenv("GITHUB_TOKEN")
 	if opts.ExcludeForks && githubRepo.GetFork() {
 		return nil, fmt.Errorf("skipping %s, excluding forks", *githubRepo.Name)
 	}
@@ -191,10 +193,18 @@ func cloneGithubRepo(githubRepo *github.Repository) (*RepoDescriptor, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to generater owner temp dir: %v", err)
 		}
-		if sshAuth != nil {
+		if sshAuth != nil && githubToken == "" {
 			repo, err = git.PlainClone(fmt.Sprintf("%s/%s", ownerDir, *githubRepo.Name), false, &git.CloneOptions{
 				URL:  *githubRepo.SSHURL,
 				Auth: sshAuth,
+			})
+		} else if githubToken != "" {
+			repo, err = git.PlainClone(fmt.Sprintf("%s/%s", ownerDir, *githubRepo.Name), false, &git.CloneOptions{
+				URL: *githubRepo.CloneURL,
+				Auth: &gitHttp.BasicAuth{
+					Username: "fakeUsername", // yes, this can be anything except an empty string
+					Password: githubToken,
+				},
 			})
 		} else {
 			repo, err = git.PlainClone(fmt.Sprintf("%s/%s", ownerDir, *githubRepo.Name), false, &git.CloneOptions{
@@ -202,10 +212,18 @@ func cloneGithubRepo(githubRepo *github.Repository) (*RepoDescriptor, error) {
 			})
 		}
 	} else {
-		if sshAuth != nil {
+		if sshAuth != nil && githubToken == "" {
 			repo, err = git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 				URL:  *githubRepo.SSHURL,
 				Auth: sshAuth,
+			})
+		} else if githubToken != "" {
+			repo, err = git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+				URL: *githubRepo.CloneURL,
+				Auth: &gitHttp.BasicAuth{
+					Username: "fakeUsername", // yes, this can be anything except an empty string
+					Password: githubToken,
+				},
 			})
 		} else {
 			repo, err = git.Clone(memory.NewStorage(), nil, &git.CloneOptions{


### PR DESCRIPTION
Gitleaks doesn't handle the case when working with github api for cloning the repo.
At the moment you can only clone repos with SSH key or if the repo is public.
When scanning an organisation with many private repos and running this on Jenkins for example without SSH key the cloning will fail with "authentication required".

Added new functionality to authenticate with same GITHUB_TOKEN provided for listing and other methods.

No tests were added as this is a bit problematic to test without real token.
Please notice that gitHttp receives a fake username and the token, the username can't be an empty string but it has no meaning, only the token matters.

I've tested the new change on my private repos and it's working as it should.

In addition, the code no longer tries to use ssh keys if providing a token (previous version defaulted to using id_rsa in ~/.ssh/ which is an issue if the user trying to clone the repo wants to clone it with the token or using normal https clone as the flow in the code automatically assumes you want to clone the repo with ssh if it finds it which it usually finds in Linux machines).

Sidenote: i'm rather new to GO so hope it's ok.