### PR TITLE
Fix Github PR checks error

### DIFF
--- a/github.go
+++ b/github.go
@@ -51,6 +51,10 @@ func auditGithubPR() ([]Leak, error) {
 			}
 			files := commit.Files
 			for _, f := range files {
+				if f.Patch == nil || f.Filename == nil {
+					continue
+				}
+
 				diff := gitDiff{
 					sha:          commit.GetSHA(),
 					content:      *f.Patch,

--- a/gitleaks_test.go
+++ b/gitleaks_test.go
@@ -311,6 +311,15 @@ func TestRun(t *testing.T) {
 				regexp.MustCompile("main.go"),
 			},
 		},
+		{
+			testOpts: Options{
+				GithubPR: "https://github.com/gitleakstest/gronit/pull/2",
+			},
+			description:    "test github pr with commits without patch info",
+			numLeaks:       0,
+			expectedErrMsg: "",
+			commitPerPage:  1,
+		},
 	}
 	g := goblin.Goblin(t)
 	for _, test := range tests {


### PR DESCRIPTION
When a commit contained a file without patch information like an added
empty file, there was a nil pointer dereference.