### PR TITLE
Change redacted behaviour on the line information

### DIFF
--- a/main.go
+++ b/main.go
@@ -669,7 +669,7 @@ func addLeak(leaks []Leak, line string, offender string, leakType string, diff g
 	}
 	if opts.Redact {
 		leak.Offender = "REDACTED"
-		leak.Line = "REDACTED"
+		leak.Line = strings.Replace(line, offender, "REDACTED", -1)
 	}
 
 	if opts.Verbose {


### PR DESCRIPTION
The line information sometimes contains useful context information so
instead of redacting the whole line, this change redacts only the
secret