### PR TITLE
fix file (#162) & line (#161) whitelist checks

### DIFF
--- a/github.go
+++ b/github.go
@@ -51,7 +51,18 @@ func auditGithubPR() ([]Leak, error) {
 			}
 			files := commit.Files
 			for _, f := range files {
+				skipFile := false
 				if f.Patch == nil || f.Filename == nil {
+					continue
+				}
+				for _, re := range whiteListFiles {
+					if re.FindString(f.GetFilename()) != "" {
+						log.Infof("skipping whitelisted file (matched regex '%s'): %s", re.String(), f.GetFilename())
+						skipFile = true
+						break
+					}
+				}
+				if skipFile {
 					continue
 				}
 

--- a/main.go
+++ b/main.go
@@ -509,6 +509,12 @@ func auditGitReference(repo *RepoDescriptor, ref *plumbing.Reference) []Leak {
 				if bin || err != nil {
 					return nil
 				}
+				for _, re := range whiteListFiles {
+					if re.FindString(f.Name) != "" {
+						log.Infof("skipping whitelisted file (matched regex '%s'): %s", re.String(), f.Name)
+						return nil
+					}
+				}
 				content, err := f.Contents()
 				if err != nil {
 					return nil
@@ -578,7 +584,9 @@ func auditGitReference(repo *RepoDescriptor, ref *plumbing.Reference) []Leak {
 					}
 					for _, re := range whiteListFiles {
 						if re.FindString(filePath) != "" {
+							log.Infof("skipping whitelisted file (matched regex '%s'): %s", re.String(), filePath)
 							skipFile = true
+							break
 						}
 					}
 					if skipFile {


### PR DESCRIPTION
* only check entropyRegexes and whiteListRegexes once per line, and only
  if regex or entropy leak type was found, since regex checks are expensive
* check whiteListFiles once for each FilePatch, instead of for
  every Chunk