### PR TITLE
Adding Stripe API Regex

### DIFF
--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -29,6 +29,9 @@ regex = '''-----BEGIN PGP PRIVATE KEY BLOCK-----'''
 [[regexes]]
 description = "Slack token"
 regex = '''xox[baprs]-.*'''
+[[regexes]]
+description = "Strip API Key"
+regex = '''(?i)(sk|pk)_(test|live)_[0-9a-zA-Z]{10,32}'''
 
 [whitelist]
 regexes = [


### PR DESCRIPTION
```
→ printf '  Stripe.api_key = "Sk_test_41u0zAKbiWmTVhvHcS6gAjp9"
  Stripe.api_key = "sk_live_VhYCleaZwuUBGSFYFc7WUboz"
  STRIPE_PUBLIC_KEY= "pk_live_8sCPFZoLtW5pXuVHGrRKrROs"' | grep -P "(?i)(sk|pk)_(test|live)_[0-9a-zA-Z]{10,32}"
```