### PR TITLE
Add support for scanning single branch

### DIFF
--- a/github.go
+++ b/github.go
@@ -159,6 +159,10 @@ func auditGithubRepos() ([]Leak, error) {
 			continue
 		}
 		leaksFromRepo, err := auditGitRepo(repo)
+		if err != nil {
+			log.Warn(err)
+			continue
+		}
 		if opts.Disk {
 			os.RemoveAll(fmt.Sprintf("%s/%s", ownerDir, *githubRepo.Name))
 		}

--- a/gitleaks_test.go
+++ b/gitleaks_test.go
@@ -320,6 +320,23 @@ func TestRun(t *testing.T) {
 			expectedErrMsg: "",
 			commitPerPage:  1,
 		},
+		{
+			testOpts: Options{
+				Repo:   "https://github.com/gitleakstest/gronit.git",
+				Branch: "master",
+			},
+			description: "test github leaks on single branch - master",
+			numLeaks:    2,
+		},
+		{
+			testOpts: Options{
+				Repo:   "https://github.com/gitleakstest/gronit.git",
+				Branch: "nonExistingBranch",
+			},
+			description:    "test github leaks on single branch which doesn't exist",
+			numLeaks:       0,
+			expectedErrMsg: "reference not found",
+		},
 	}
 	g := goblin.Goblin(t)
 	for _, test := range tests {

--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
-
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 
@@ -69,8 +69,9 @@ type Options struct {
 	GitLabUser string `long:"gitlab-user" description:"GitLab user ID to audit"`
 	GitLabOrg  string `long:"gitlab-org" description:"GitLab group ID to audit"`
 
-	Commit string `short:"c" long:"commit" description:"sha of commit to stop at"`
-	Depth  int    `long:"depth" description:"maximum commit depth"`
+	Commit string                 `short:"c" long:"commit" description:"sha of commit to stop at"`
+	Depth  int                    `long:"depth" description:"maximum commit depth"`
+	Branch plumbing.ReferenceName `long:"branch" description:"scan remote branch only (default is all)"`
 
 	// local target option
 	RepoPath  string `long:"repo-path" description:"Path to repo"`
@@ -429,6 +430,7 @@ func auditGitRepo(repo *RepoDescriptor) ([]Leak, error) {
 	var (
 		err   error
 		leaks []Leak
+		refs  storer.ReferenceIter
 	)
 	for _, re := range whiteListRepos {
 		if re.FindString(repo.name) != "" {
@@ -439,7 +441,21 @@ func auditGitRepo(repo *RepoDescriptor) ([]Leak, error) {
 	// clear commit cache
 	commitMap = make(map[string]bool)
 
-	refs, err := repo.repository.Storer.IterReferences()
+	if opts.Branch != "" {
+		// var branchRef plumbing.ReferenceName
+		branchRef := "refs/remotes/origin/" + opts.Branch
+		log.Debugf("Auditing ref: %v", branchRef)
+		ref, err := repo.repository.Storer.Reference(branchRef)
+		if err != nil {
+			return leaks, err
+		}
+		branchLeaks := auditGitReference(repo, ref)
+		for _, leak := range branchLeaks {
+			leaks = append(leaks, leak)
+		}
+		return leaks, nil
+	}
+	refs, err = repo.repository.Storer.IterReferences()
 	if err != nil {
 		return leaks, err
 	}


### PR DESCRIPTION
# Description

Added a new command line argument ```--branch``` this provides a way to scan only single remote branch e.g. ```refs/remotes/origin/master```
While the the default (when not adding ```--branch``` remains the same and will scan all refs.
The motivation to add this feature is that we can now scan more quickly and only scan the branches we want. In normal scan we also scan HEAD, refs/heads/master which many times are all the same.

## Type of change


- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested manually by running gitleaks --branch=master (or anything else)

1. Test without ```--branch```
```
INFO[2018-12-29T00:52:05+02:00] cloning: aws-scripts
INFO[2018-12-29T00:52:09+02:00] HEAD
INFO[2018-12-29T00:52:10+02:00] refs/remotes/origin/master
INFO[2018-12-29T00:52:10+02:00] refs/remotes/origin/python_package
INFO[2018-12-29T00:52:10+02:00] refs/heads/master
```

2. Test with ```--branch=master```
```
INFO[2018-12-29T13:09:24+02:00] cloning: aws-scripts
DEBU[2018-12-29T13:09:26+02:00] Auditing ref: refs/remotes/origin/master
INFO[2018-12-29T13:09:26+02:00] no leaks found for repo aws-scripts
```

3. Test with ```--branch=python_package```
```
INFO[2018-12-29T13:09:39+02:00] cloning: aws-scripts
DEBU[2018-12-29T13:09:42+02:00] Auditing ref: refs/remotes/origin/python_package
INFO[2018-12-29T13:09:42+02:00] no leaks found for repo aws-scripts
```
