### PR TITLE
Fix for the github default regex

### DIFF
--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -10,7 +10,7 @@ description = "RSA"
 regex = '''-----BEGIN RSA PRIVATE KEY-----'''
 [[regexes]]
 description = "Github"
-regex = '''(?i)github.*['\"][0-9a-zA-Z]{35,40}['\"]'''
+regex = '''(?!github.com\/)(?i)github.*['\"][0-9a-zA-Z]{35,40}['\"]'''
 [[regexes]]
 description = "SSH"
 regex = '''-----BEGIN OPENSSH PRIVATE KEY-----'''

--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -10,7 +10,7 @@ description = "RSA"
 regex = '''-----BEGIN RSA PRIVATE KEY-----'''
 [[regexes]]
 description = "Github"
-regex = '''(?!github.com\/)(?i)github.*['\"][0-9a-zA-Z]{35,40}['\"]'''
+regex = '''([^github.com])(?i)github.*['\"][0-9a-zA-Z]{35,40}['\"]'''
 [[regexes]]
 description = "SSH"
 regex = '''-----BEGIN OPENSSH PRIVATE KEY-----'''


### PR DESCRIPTION
Exclude finding if the line has reference to github.com which could pull a repo ref hash and be a false positive
Issue https://github.com/zricethezav/gitleaks/issues/175