### PR TITLE
Fix logging of repo paths

### DIFF
--- a/src/repo.go
+++ b/src/repo.go
@@ -83,10 +83,10 @@ func (repoInfo *RepoInfo) clone() error {
 			})
 		}
 	} else if repoInfo.path != "" {
-		log.Infof("opening %s", opts.RepoPath)
+		log.Infof("opening %s", repoInfo.path)
 		repo, err = git.PlainOpen(repoInfo.path)
 		if err != nil {
-			log.Errorf("unable to open %s", opts.RepoPath)
+			log.Errorf("unable to open %s", repoInfo.path)
 		}
 	} else {
 		// cloning to memory


### PR DESCRIPTION
This fixes a simple bug when logging the path of repos, which was coming out empty.

Output before fix:
```
$ docker run --rm -ti -v /projects:/projects gitleaks --log=debug --owner-path /projects
INFO[2019-05-06T13:35:06Z] opening
```
...and after fix:
```
$ docker run --rm -ti -v /projects:/projects gitleaks --log=debug --owner-path /projects
INFO[2019-05-06T13:51:16Z] opening /projects/sample_project
```
There was not an issue logged for this that I could find, and it was such a small bug, so I have not updated the changelog. The tests pass. Hope you can take the change anyway.

P.S. Thank you very much for writing and contributing your tool!