### PR TITLE
Modify single commit audit

### DIFF
--- a/src/repo.go
+++ b/src/repo.go
@@ -209,13 +209,6 @@ func (repoInfo *RepoInfo) audit() ([]Leak, error) {
 			mutex.Lock()
 			leaks = append(leaksFromSingleCommit, leaks...)
 			mutex.Unlock()
-			if opts.Commit == c.Hash.String() {
-				return storer.ErrStop
-			}
-			return nil
-		}
-
-		if opts.Commit != "" && opts.Commit != c.Hash.String() {
 			return nil
 		}
 


### PR DESCRIPTION
I'm trying to use `gitleaks` as part of a pre-receive hook script in github enterprise. My goal is to inspect every commit after a push occurs and before any refs are updated on the remote repository. For that, I'm running `gitleaks --commit` for every commit. 

The problem I'm facing is that `gitleaks` current implementation using `git log --all` doesn't find the commit within the git-receive-pack received with the push.
 
My proposal is to simplify the single commit audit:
When using the `--commit` flag, we can skip creating a collection of commits and we can skip iterating through this list. This approach is more straightforward and it enables using `gitleaks` as part of a pre-receive hook script in github enterprise.