### PR TITLE
Solved bug on error being overwritten and not passed to postAudit, closes #223

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/zricethezav/gitleaks/src"
+	gitleaks "github.com/zricethezav/gitleaks/src"
 )
 
 func main() {
 	report, err := gitleaks.Run(gitleaks.ParseOpts())
 	if err != nil {
+		if strings.Contains(err.Error(), "whitelisted") {
+			log.Info(err.Error())
+			os.Exit(0)
+		}
 		log.Error(err)
 		os.Exit(gitleaks.ErrExit)
 	}

--- a/src/core.go
+++ b/src/core.go
@@ -3,7 +3,6 @@ package gitleaks
 import (
 	"io/ioutil"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -60,7 +59,8 @@ func Run(optsL *Options) (*Report, error) {
 
 	// start audits
 	if opts.Repo != "" || opts.RepoPath != "" {
-		repoInfo, err := newRepoInfo()
+		var repoInfo *RepoInfo
+		repoInfo, err = newRepoInfo()
 		if err != nil {
 			goto postAudit
 		}
@@ -70,7 +70,8 @@ func Run(optsL *Options) (*Report, error) {
 		}
 		leaks, err = repoInfo.audit()
 	} else if opts.OwnerPath != "" {
-		repoDs, err := discoverRepos(opts.OwnerPath)
+		var repoDs []*RepoInfo
+		repoDs, err = discoverRepos(opts.OwnerPath)
 		if err != nil {
 			goto postAudit
 		}
@@ -96,12 +97,7 @@ func Run(optsL *Options) (*Report, error) {
 
 postAudit:
 	if err != nil {
-		if strings.Contains(err.Error(), "whitelisted") {
-			log.Info(err.Error())
-			os.Exit(0)
-		}
-		log.Error(err)
-		os.Exit(ErrExit)
+		return &Report{}, err
 	}
 
 	if opts.Report != "" {

--- a/src/gitleaks_test.go
+++ b/src/gitleaks_test.go
@@ -206,7 +206,7 @@ func TestRun(t *testing.T) {
 			},
 			description:    "test empty",
 			numLeaks:       0,
-			expectedErrMsg: "reference not found",
+			expectedErrMsg: "repository not found",
 		},
 		{
 			testOpts: &Options{

--- a/src/repo.go
+++ b/src/repo.go
@@ -15,6 +15,7 @@ import (
 	diffType "gopkg.in/src-d/go-git.v4/plumbing/format/diff"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+	gitHttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 )
 
@@ -98,10 +99,17 @@ func (repoInfo *RepoInfo) clone() error {
 				Auth:     config.sshAuth,
 			})
 		} else {
-			repo, err = git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+			options := &git.CloneOptions{
 				URL:      opts.Repo,
 				Progress: os.Stdout,
-			})
+			}
+			if os.Getenv("GITHUB_TOKEN") != "" {
+				options.Auth = &gitHttp.BasicAuth{
+					Username: "fakeUsername", // yes, this can be anything except an empty string
+					Password: os.Getenv("GITHUB_TOKEN"),
+				}
+			}
+			repo, err = git.Clone(memory.NewStorage(), nil, options)
 		}
 	}
 	repoInfo.repository = repo


### PR DESCRIPTION
The err variable is being overwritten and it reaches postAudit always as nil.

You can test this by running:
```
$ gitleaks --repo-path ../does-not-exist
?[36mINFO?[0m[2019-05-28T15:37:59-07:00] opening ../does-not-exist
?[31mERRO?[0m[2019-05-28T15:37:59-07:00] unable to open ../does-not-exist
?[36mINFO?[0m[2019-05-28T15:37:59-07:00] 0 leaks detected. 0 commits inspected in 1 second 505 milliseconds
```
With this patch it start capturing the error:
```
$ go run . --repo-path ../does-not-exist
?[36mINFO?[0m[2019-05-28T15:39:02-07:00] opening ../does-not-exist
?[31mERRO?[0m[2019-05-28T15:39:02-07:00] unable to open ../does-not-exist
?[31mERRO?[0m[2019-05-28T15:39:02-07:00] repository does not exist
exit status 2
```

This PR closes #223 .