### PR TITLE
Fix updating config from repo-config

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -197,7 +197,7 @@ func (config *Config) updateFromRepo(repo *RepoInfo) error {
 	if err != nil {
 		return err
 	}
-	if _, err := toml.DecodeReader(f, &config); err != nil {
+	if _, err := toml.DecodeReader(f, &tomlConfig); err != nil {
 		return fmt.Errorf("problem loading config: %v", err)
 	}
 	f.Close()


### PR DESCRIPTION
Gitleaks was not correctly updating its config from .gitleaks.toml in the target repository when `--repo-config` was used.