### PR TITLE
constants.go(enhance): added an enhancement to include apikey without…

### DIFF
--- a/src/constants.go
+++ b/src/constants.go
@@ -109,7 +109,7 @@ tags = ["key", "EC"]
 
 [[rules]]
 description = "Generic API key"
-regex = '''(?i)api_key(.{0,20})?['|"][0-9a-zA-Z]{32,45}['|"]'''
+regex = '''(?i)(api_key|apikey)(.{0,20})?['|"][0-9a-zA-Z]{32,45}['|"]'''
 tags = ["key", "API", "generic"]
 
 [[rules]]


### PR DESCRIPTION
… underscore as another detection for api keys detection rule in gitleaks - noticed that gitleaks rule does not appear to be picking up indications of "apikey" (without underscore) so have made a minor change to include this rule.