### PR TITLE
Regex whitelist example in sample config

### DIFF
--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -180,6 +180,9 @@ tags = ["key", "twilio"]
 files = [
   "(.*?)(jpg|gif|doc|pdf|bin)$"
 ]
+#regexes = [
+#  "AKIAIOSFODNN7EXAMPLE"
+#]
 #commits = [
 #  "whitelisted-commit1",
 #  "whitelisted-commit2",


### PR DESCRIPTION
Users looking to the sample config to discover possible options may
not notice that its possible to whitelist by regex. This commit adds
an example to aid discovery.

Related: conjurinc/ops#246