### PR TITLE
fix(repo-config): avoid SIGSEGV if there is no .gitleaks.toml

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -194,10 +194,10 @@ func (config *Config) updateFromRepo(repo *Repo) error {
 		return err
 	}
 	f, err := wt.Filesystem.Open(".gitleaks.toml")
-	defer f.Close()
 	if err != nil {
 		return fmt.Errorf("problem loading config: %v", err)
 	}
+	defer f.Close()
 	if _, err := toml.DecodeReader(f, &tomlConfig); err != nil {
 		return fmt.Errorf("problem loading config: %v", err)
 	}


### PR DESCRIPTION
Do not crash if no `.gitleaks.toml` is available:

```
gitleaks --repo-path=./ --report=leaks.json --repo-config
INFO[2019-09-08T13:07:52+02:00] opening ./                                   
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15b420d]

goroutine 1 [running]:
github.com/zricethezav/gitleaks/src.(*Config).updateFromRepo(0xc00015e000, 0xc00023c780, 0x0, 0x0)
	/private/tmp/gitleaks-20190803-33929-1izxwdf/gitleaks-2.1.0/github.com/zricethezav/gitleaks/src/config.go:197 +0x10d
github.com/zricethezav/gitleaks/src.(*Repo).audit(0xc00023c780, 0x0, 0x0)
	/private/tmp/gitleaks-20190803-33929-1izxwdf/gitleaks-2.1.0/github.com/zricethezav/gitleaks/src/repo.go:165 +0x82f
github.com/zricethezav/gitleaks/src.Run(0xc0000feb40, 0x0, 0x0, 0x0)
	/private/tmp/gitleaks-20190803-33929-1izxwdf/gitleaks-2.1.0/github.com/zricethezav/gitleaks/src/core.go:65 +0x105
main.main()
	/private/tmp/gitleaks-20190803-33929-1izxwdf/gitleaks-2.1.0/github.com/zricethezav/gitleaks/main.go:12 +0x2b
```