### PR TITLE
feat(repo-config): do not fail if no repo-config is available

### DIFF
--- a/src/repo.go
+++ b/src/repo.go
@@ -164,7 +164,7 @@ func (repo *Repo) audit() error {
 	if opts.RepoConfig {
 		err := config.updateFromRepo(repo)
 		if err != nil {
-			return err
+			log.Warn(err)
 		}
 	}
 


### PR DESCRIPTION
Just print a warning if no `.gitleaks.toml` is found.

```
WARN[2019-09-08T20:48:06+02:00] problem loading config: open /Users/roger/targetrepo/.gitleaks.toml: no such file or directory
```

This will make it possible to pass `--repo-config` within a script for all repos.
So each repo can override the config with a `.gitleaks.toml` and the scan will proceed with default or provided config if there's no config within the repo. Otherwise a probe for `.gitleaks.toml` would be required to selectively use the `--repo-config` option.

