### PR TITLE
add rule for DSA keys

### DIFF
--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -32,6 +32,11 @@ regex = '''-----BEGIN RSA PRIVATE KEY-----'''
 tags = ["key", "RSA"]
 
 [[rules]]
+description = "DSA"
+regex = '''-----BEGIN DSA PRIVATE KEY-----'''
+tags = ["key", "DSA"]
+
+[[rules]]
 description = "SSH"
 regex = '''-----BEGIN OPENSSH PRIVATE KEY-----'''
 tags = ["key", "SSH"]


### PR DESCRIPTION
Just like for `RSA`, introduce a rule to look for `DSA` keys.