### PR TITLE
feat/report-writer: supporting AWS S3 and syslog, and multiple report outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 examples
 src/gitleaksConfig
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,27 @@
-.PHONY: test build-all deploy
+.PHONY: test build-all build-deps build-os deploy
 
 test:
 	go get golang.org/x/lint/golint
 	go fmt
 	golint
 	go test --race --cover github.com/zricethezav/gitleaks/src -v
+
 deploy:
 	@echo "$(DOCKER_PASSWORD)" | docker login -u "$(DOCKER_USERNAME)" --password-stdin
 	docker build -f Dockerfile -t $(REPO):$(TAG) .
 	echo "Pushing $(REPO):$(COMMIT) $(REPO):$(TAG)"
 	docker push $(REPO)
-build-all:
+
+build-deps:
 	rm -rf build
 	mkdir build
+
+GOOS ?= linux
+GOARCH ?= amd64
+build-os: build-deps
+	env GOOS="$(GOOS)" GOARCH="$(GOARCH)" go build -o "build/gitleaks-$(GOOS)-$(GOARCH)"
+
+build-all: build-deps
 	env GOOS="windows" GOARCH="amd64" go build -o "build/gitleaks-windows-amd64.exe"
 	env GOOS="windows" GOARCH="386" go build -o "build/gitleaks-windows-386.exe"
 	env GOOS="linux" GOARCH="amd64" go build -o "build/gitleaks-linux-amd64"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,54 @@ By default repos cloned to memory. Using `--disk` for clone to disk or you can q
 
 For speed up analyze operation using `--threads` parameter, which set to `ALL - 1` treads at your instance CPU.
 
+### Options examples
+
+Run gitleaks and save report to **CSV file** `/tmp/zricethezav-gitleaks.csv`:
+
+```bash
+docker run --rm --name=gitleaks zricethezav/gitleaks \
+  -v -r https://github.com/zricethezav/gitleaks.git \
+  --report /tmp/zricethezav-gitleaks.csv
+```
+
+Run gitleaks and save report to **JSON file** `/tmp/zricethezav-gitleaks.json`:
+
+```bash
+docker run --rm --name=gitleaks zricethezav/gitleaks \
+  -v -r https://github.com/zricethezav/gitleaks.git \
+  --report /tmp/zricethezav-gitleaks.json
+```
+
+Run gitleaks and save report on **AWS S3 Bucket/Object** `s3://myLeaksRepo/zricethezav/gitleaks.json`:
+
+```bash
+docker run --rm --name=gitleaks zricethezav/gitleaks \
+  -v -r https://github.com/zricethezav/gitleaks.git \
+  --report s3://myLeaksRepo/zricethezav/gitleaks.json
+```
+
+Run gitleaks and send report to **Remote TCP Syslog Server** `syslog://tcp:10.10.10.10:10514/gitleaks-docker`:
+
+Syntax: `syslog://PROTO:IP_DNS:PORT/TAG`
+
+* `PROTO`: Protocol. TCP or UDP
+* `IP_DNS`: IP or DNS address for syslog server
+* `PORT`: TCP or UDP port for syslog server
+* `TAG`: Tag (aka `programname`) to label the message on the server
+
+```bash
+docker run --rm --name=gitleaks zricethezav/gitleaks \
+  -v -r https://github.com/zricethezav/gitleaks.git \
+  --report syslog://tcp:10.10.10.10:10514/gitleaks-docker
+```
+
+Run gitleaks, and **save to JSON** file **AND** send report to **Remote TCP Syslog Server** `syslog://tcp:10.10.10.10:10514/gitleaks-docker`:
+
+```bash
+docker run --rm --name=gitleaks zricethezav/gitleaks \
+  -v -r https://github.com/zricethezav/gitleaks.git \
+  --report /tmp/zricethezav-gitleaks.json,syslog://tcp:10.10.10.10:10514/gitleaks-docker
+```
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Audit git repos for secrets. Gitleaks provides a way for you to find unencrypted
 * Github and Gitlab support including support for bulk organization and repository owner (user) repository scans, as well as pull request scanning for use in common CI workflows.
 * Support for private repository scans, and repositories that require key based authentication
 * Output in CSV and JSON formats for consumption in other reporting tools and frameworks
+* Output JSON can be saved both in AWS S3 block storage or in remote syslog server
 * Externalised configuration for environment specific customisation including regex rules
 * Customizable repository name, file type, commit ID, branch name and regex whitelisting to reduce false positives
 * High performance through the use of src-d's [go-git](https://github.com/src-d/go-git) framework
@@ -81,7 +82,7 @@ Application Options:
       --branch=         Branch to audit
   -l, --log=            log level
   -v, --verbose         Show verbose output from gitleaks audit
-      --report=         path to write report file
+      --report=         path to write report file. Needs to be csv, json, s3://bucket/obj or syslog://tcp:target:port/tag
       --redact          redact secrets from log messages and report
       --version         version number
       --sample-config   prints a sample config file

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/zricethezav/gitleaks
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/Devatoria/go-graylog v0.0.0-20171023211614-c16c35c9383b
-	github.com/Jeffail/gabs v1.4.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.27
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/franela/goblin v0.0.0-20181003173013-ead4ad1d2727
@@ -21,7 +19,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
 	google.golang.org/appengine v1.2.0 // indirect
-	gopkg.in/Graylog2/go-gelf.v1 v1.0.0-20170811154226-7ebf4f536d8f
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/zricethezav/gitleaks
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Devatoria/go-graylog v0.0.0-20171023211614-c16c35c9383b
+	github.com/Jeffail/gabs v1.4.0 // indirect
 	github.com/aws/aws-sdk-go v1.25.27
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/franela/goblin v0.0.0-20181003173013-ead4ad1d2727
@@ -19,6 +21,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
 	google.golang.org/appengine v1.2.0 // indirect
+	gopkg.in/Graylog2/go-gelf.v1 v1.0.0-20170811154226-7ebf4f536d8f
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/zricethezav/gitleaks
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/aws/aws-sdk-go v1.25.27
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/franela/goblin v0.0.0-20181003173013-ead4ad1d2727
 	github.com/google/go-github v15.0.0+incompatible
@@ -23,3 +24,5 @@ require (
 	gopkg.in/src-d/go-billy.v4 v4.3.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.9.1
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBb
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/aws/aws-sdk-go v1.25.27 h1:UANmajXi1Vn7eZ9GgdDtkFjxDiaHY6tUixCiB6Bj128=
+github.com/aws/aws-sdk-go v1.25.27/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.9.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
@@ -35,6 +37,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e h1:RgQk53JHp/Cjunrr1WlsXSZpqXn+uREuHvUVcK82CV8=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Devatoria/go-graylog v0.0.0-20171023211614-c16c35c9383b h1:H8ZRQ2Vs1kp+ISXE8MFsRURsho7vc+Timp3SqaRTehU=
-github.com/Devatoria/go-graylog v0.0.0-20171023211614-c16c35c9383b/go.mod h1:Q5NeCyxEC7q3hz6x5Wd0e5YD/Vhq2qwQlY+Eo767Ch8=
-github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
-github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
@@ -110,8 +106,6 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/appengine v1.2.0 h1:S0iUepdCWODXRvtE+gcRDd15L+k+k1AiHlMiMjefH24=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-gopkg.in/Graylog2/go-gelf.v1 v1.0.0-20170811154226-7ebf4f536d8f h1:Rle3NzY1O9cyXt1MHSERAzpbR8D4wTvO3vRsgBsr8WI=
-gopkg.in/Graylog2/go-gelf.v1 v1.0.0-20170811154226-7ebf4f536d8f/go.mod h1:m1PYiRvT4jG4oTm1H+OM5VC6sLyS+7aNCuI1qowlogM=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Devatoria/go-graylog v0.0.0-20171023211614-c16c35c9383b h1:H8ZRQ2Vs1kp+ISXE8MFsRURsho7vc+Timp3SqaRTehU=
+github.com/Devatoria/go-graylog v0.0.0-20171023211614-c16c35c9383b/go.mod h1:Q5NeCyxEC7q3hz6x5Wd0e5YD/Vhq2qwQlY+Eo767Ch8=
+github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
+github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
@@ -106,6 +110,8 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/appengine v1.2.0 h1:S0iUepdCWODXRvtE+gcRDd15L+k+k1AiHlMiMjefH24=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+gopkg.in/Graylog2/go-gelf.v1 v1.0.0-20170811154226-7ebf4f536d8f h1:Rle3NzY1O9cyXt1MHSERAzpbR8D4wTvO3vRsgBsr8WI=
+gopkg.in/Graylog2/go-gelf.v1 v1.0.0-20170811154226-7ebf4f536d8f/go.mod h1:m1PYiRvT4jG4oTm1H+OM5VC6sLyS+7aNCuI1qowlogM=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/src/options.go
+++ b/src/options.go
@@ -129,12 +129,10 @@ func (opts *Options) guard() error {
 		if !strings.HasSuffix(opts.Report, ".json") &&
 			!strings.HasSuffix(opts.Report, ".csv") &&
 			!strings.HasPrefix(opts.Report, "s3://") &&
-			!strings.HasPrefix(opts.Report, "gelf://") &&
 			!strings.HasPrefix(opts.Report, "syslog://") {
-			return fmt.Errorf("Report should be a .json, .csv, s3://, gelf:// or syslog://")
+			return fmt.Errorf("Report should be a .json, .csv, s3://, or syslog://")
 		}
 		if !strings.HasPrefix(opts.Report, "s3://") &&
-			!strings.HasPrefix(opts.Report, "gelf://") &&
 			!strings.HasPrefix(opts.Report, "syslog://") {
 			dirPath := filepath.Dir(opts.Report)
 			if _, err := os.Stat(dirPath); os.IsNotExist(err) {

--- a/src/options.go
+++ b/src/options.go
@@ -129,11 +129,13 @@ func (opts *Options) guard() error {
 		if !strings.HasSuffix(opts.Report, ".json") &&
 			!strings.HasSuffix(opts.Report, ".csv") &&
 			!strings.HasPrefix(opts.Report, "s3://") &&
-			!strings.HasPrefix(opts.Report, "tcp://") {
+			!strings.HasPrefix(opts.Report, "tcp://") &&
+			!strings.HasPrefix(opts.Report, "syslog://") {
 			return fmt.Errorf("Report should be a .json or .csv file")
 		}
 		if !strings.HasPrefix(opts.Report, "s3://") &&
-			!strings.HasPrefix(opts.Report, "tcp://") {
+			!strings.HasPrefix(opts.Report, "tcp://") &&
+			!strings.HasPrefix(opts.Report, "syslog://") {
 			dirPath := filepath.Dir(opts.Report)
 			if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 				return fmt.Errorf("%s does not exist", dirPath)

--- a/src/options.go
+++ b/src/options.go
@@ -48,7 +48,7 @@ type Options struct {
 	// Output options
 	Log          string `short:"l" long:"log" description:"log level"`
 	Verbose      bool   `short:"v" long:"verbose" description:"Show verbose output from gitleaks audit"`
-	Report       string `long:"report" description:"path to write report file. Needs to be csv or json"`
+	Report       string `long:"report" description:"path to write report file. Needs to be csv, json, s3://bucket/obj or tcp://target:port"`
 	Redact       bool   `long:"redact" description:"redact secrets from log messages and report"`
 	Version      bool   `long:"version" description:"version number"`
 	SampleConfig bool   `long:"sample-config" description:"prints a sample config file"`
@@ -126,12 +126,18 @@ func (opts *Options) guard() error {
 	}
 
 	if opts.Report != "" {
-		if !strings.HasSuffix(opts.Report, ".json") && !strings.HasSuffix(opts.Report, ".csv") {
+		if !strings.HasSuffix(opts.Report, ".json") &&
+			!strings.HasSuffix(opts.Report, ".csv") &&
+			!strings.HasPrefix(opts.Report, "s3://") &&
+			!strings.HasPrefix(opts.Report, "tcp://") {
 			return fmt.Errorf("Report should be a .json or .csv file")
 		}
-		dirPath := filepath.Dir(opts.Report)
-		if _, err := os.Stat(dirPath); os.IsNotExist(err) {
-			return fmt.Errorf("%s does not exist", dirPath)
+		if !strings.HasPrefix(opts.Report, "s3://") &&
+			!strings.HasPrefix(opts.Report, "tcp://") {
+			dirPath := filepath.Dir(opts.Report)
+			if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+				return fmt.Errorf("%s does not exist", dirPath)
+			}
 		}
 	}
 

--- a/src/options.go
+++ b/src/options.go
@@ -48,7 +48,7 @@ type Options struct {
 	// Output options
 	Log          string `short:"l" long:"log" description:"log level"`
 	Verbose      bool   `short:"v" long:"verbose" description:"Show verbose output from gitleaks audit"`
-	Report       string `long:"report" description:"path to write report file. Needs to be csv, json, s3://bucket/obj or tcp://target:port"`
+	Report       string `long:"report" description:"path to write report file. Needs to be csv, json, s3://bucket/obj or syslog://tcp:target:port/tag"`
 	Redact       bool   `long:"redact" description:"redact secrets from log messages and report"`
 	Version      bool   `long:"version" description:"version number"`
 	SampleConfig bool   `long:"sample-config" description:"prints a sample config file"`

--- a/src/options.go
+++ b/src/options.go
@@ -129,12 +129,12 @@ func (opts *Options) guard() error {
 		if !strings.HasSuffix(opts.Report, ".json") &&
 			!strings.HasSuffix(opts.Report, ".csv") &&
 			!strings.HasPrefix(opts.Report, "s3://") &&
-			!strings.HasPrefix(opts.Report, "tcp://") &&
+			!strings.HasPrefix(opts.Report, "gelf://") &&
 			!strings.HasPrefix(opts.Report, "syslog://") {
-			return fmt.Errorf("Report should be a .json or .csv file")
+			return fmt.Errorf("Report should be a .json, .csv, s3://, gelf:// or syslog://")
 		}
 		if !strings.HasPrefix(opts.Report, "s3://") &&
-			!strings.HasPrefix(opts.Report, "tcp://") &&
+			!strings.HasPrefix(opts.Report, "gelf://") &&
 			!strings.HasPrefix(opts.Report, "syslog://") {
 			dirPath := filepath.Dir(opts.Report)
 			if _, err := os.Stat(dirPath); os.IsNotExist(err) {


### PR DESCRIPTION
Supporting new report outputs to:
- AWS S3 bucket
- syslog remote server
- multiple outputs

## AWS S3 bucket

The output object will be saved in **JSON** format directly to the object path in argument --report.  See more on README

## Syslog

The output object will be saved in **JSON** sending the payload, by leak result, to Sylog server. See more on README

## Multiple output

Now, to keep compatibility and improve the report options, multiple outputs could be informed spited by comma. See more on README