### PR TITLE
Update asymmetric private key regex

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -62,9 +62,9 @@ title = "gitleaks config"
 	tags = ["key", "Slack"]
 
 [[rules]]
-	description = "EC"
-	regex = '''-----BEGIN EC PRIVATE KEY-----'''
-	tags = ["key", "EC"]
+	description = "Asymmetric Private Key"
+	regex = '''-----BEGIN (EC|PGP|DSA|RSA|OPENSSH) PRIVATE KEY( BLOCK)?-----'''
+	tags = ["key", "AsymmetricPrivateKey"]
 
 [[rules]]
 	description = "Generic Credential"


### PR DESCRIPTION
There is currently only a single regex for Asymmetric Private Keys, which covers just the EC key type. It would be better to extend this to include all types. For example this updated regex will match each of the following:

```
-----BEGIN RSA PRIVATE KEY-----
-----BEGIN DSA PRIVATE KEY-----
-----BEGIN EC PRIVATE KEY-----
-----BEGIN PGP PRIVATE KEY BLOCK-----
-----BEGIN OPENSSH PRIVATE KEY-----
```