### PR TITLE
Updating generic credentials regex

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -68,7 +68,7 @@ title = "gitleaks config"
 
 [[rules]]
 	description = "Generic Credential"
-	regex = '''(?i)(api_key|apikey|secret)(.{0,20})?['|"][0-9a-zA-Z]{16,45}['|"]'''
+	regex = '''(?i)['"]?[\w-_]*(apikey|api_key|secret|token)[\w-_]*['"]?\s*[=:]\s*('(?:[^'\\]|\\.){6,100}'|"(?:[^"\\]|\\.){6,100}")'''
 	tags = ["key", "API", "generic"]
 
 [[rules]]

--- a/test_data/test_local_owner_aws_leak.json
+++ b/test_data/test_local_owner_aws_leak.json
@@ -13,6 +13,19 @@
   "tags": "key, AWS"
  },
  {
+  "line": "    aws_secret_access_key='ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'",
+  "offender": "aws_secret_access_key='ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'",
+  "commit": "6557c92612d3b35979bd426d429255b3bf9fab74",
+  "repo": "test_repo_1",
+  "rule": "Generic Credential",
+  "commitMessage": "commit 1 with secrets\n",
+  "author": "zach rice",
+  "email": "zricer@protonmail.com",
+  "file": "server.test.py",
+  "date": "2019-10-24T09:29:27-04:00",
+  "tags": "key, API, generic"
+ },
+ {
   "line": "    const AWSKEY = \"AKIALALEMEL33243OLIBE\"",
   "offender": "AKIALALEMEL33243OLIB",
   "commit": "f61cd8587b7ac1d75a89a0c9af870a2f24c60263",
@@ -27,7 +40,7 @@
  },
  {
   "line": "    const AWSSECRET = \"99432bfewaf823ec3294e231\"",
-  "offender": "SECRET = \"99432bfewaf823ec3294e231\"",
+  "offender": "AWSSECRET = \"99432bfewaf823ec3294e231\"",
   "commit": "f61cd8587b7ac1d75a89a0c9af870a2f24c60263",
   "repo": "test_repo_2",
   "rule": "Generic Credential",
@@ -53,7 +66,7 @@
  },
  {
   "line": "    const AWSSECRET = \"99432bfewaf823ec3294e231\"",
-  "offender": "SECRET = \"99432bfewaf823ec3294e231\"",
+  "offender": "AWSSECRET = \"99432bfewaf823ec3294e231\"",
   "commit": "b2eb34a61c988afd9b4aaa9dd58c8dd7d5f14dba",
   "repo": "test_repo_2",
   "rule": "Generic Credential",
@@ -144,7 +157,7 @@
  },
  {
   "line": "const AWSSECRET = \"99432bfewaf823ec3294e231\"",
-  "offender": "SECRET = \"99432bfewaf823ec3294e231\"",
+  "offender": "AWSSECRET = \"99432bfewaf823ec3294e231\"",
   "commit": "cd5eb8bef855f73c46b97b4c088badffdc40ebe9",
   "repo": "test_repo_3",
   "rule": "Generic Credential",
@@ -170,7 +183,7 @@
  },
  {
   "line": "const AWSSECRET = \"99432bfewaf823ec3294e231\"",
-  "offender": "SECRET = \"99432bfewaf823ec3294e231\"",
+  "offender": "AWSSECRET = \"99432bfewaf823ec3294e231\"",
   "commit": "84ac4e80d4dbf2c968b64e9d4005f5079795bb81",
   "repo": "test_repo_3",
   "rule": "Generic Credential",

--- a/test_data/test_local_repo_one_aws_leak.json
+++ b/test_data/test_local_repo_one_aws_leak.json
@@ -11,5 +11,18 @@
   "file": "server.test.py",
   "date": "2019-10-24T09:29:27-04:00",
   "tags": "key, AWS"
+ },
+ {
+  "line": "    aws_secret_access_key='ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'",
+  "offender": "aws_secret_access_key='ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'",
+  "commit": "6557c92612d3b35979bd426d429255b3bf9fab74",
+  "repo": "test_repo_1",
+  "rule": "Generic Credential",
+  "commitMessage": "commit 1 with secrets\n",
+  "author": "zach rice",
+  "email": "zricer@protonmail.com",
+  "file": "server.test.py",
+  "date": "2019-10-24T09:29:27-04:00",
+  "tags": "key, API, generic"
  }
 ]

--- a/test_data/test_local_repo_one_aws_leak_commit.json
+++ b/test_data/test_local_repo_one_aws_leak_commit.json
@@ -11,5 +11,18 @@
   "file": "server.test.py",
   "date": "2019-10-24T09:29:27-04:00",
   "tags": "key, AWS"
+ },
+ {
+  "line": "    aws_secret_access_key='ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'",
+  "offender": "aws_secret_access_key='ABCDEF+c2L7yXeGvUyrPgYsDnWRRC1AYEXAMPLE'",
+  "commit": "6557c92612d3b35979bd426d429255b3bf9fab74",
+  "repo": "test_repo_1",
+  "rule": "Generic Credential",
+  "commitMessage": "commit 1 with secrets\n",
+  "author": "zach rice",
+  "email": "zricer@protonmail.com",
+  "file": "server.test.py",
+  "date": "2019-10-24T09:29:27-04:00",
+  "tags": "key, API, generic"
  }
 ]

--- a/test_data/test_local_repo_two_leaks.json
+++ b/test_data/test_local_repo_two_leaks.json
@@ -14,7 +14,7 @@
  },
  {
   "line": "    const AWSSECRET = \"99432bfewaf823ec3294e231\"",
-  "offender": "SECRET = \"99432bfewaf823ec3294e231\"",
+  "offender": "AWSSECRET = \"99432bfewaf823ec3294e231\"",
   "commit": "f61cd8587b7ac1d75a89a0c9af870a2f24c60263",
   "repo": "test_repo_2",
   "rule": "Generic Credential",
@@ -40,7 +40,7 @@
  },
  {
   "line": "    const AWSSECRET = \"99432bfewaf823ec3294e231\"",
-  "offender": "SECRET = \"99432bfewaf823ec3294e231\"",
+  "offender": "AWSSECRET = \"99432bfewaf823ec3294e231\"",
   "commit": "b2eb34a61c988afd9b4aaa9dd58c8dd7d5f14dba",
   "repo": "test_repo_2",
   "rule": "Generic Credential",


### PR DESCRIPTION
I found the default regex for the generic credentials was not able to find as many secrets as I anticipated. I've tried to make some improvements to this, let me know what your thoughts are.

**Features:**
1. Extend keywords to include `token`.
2. Be more prescriptive around what characters can surround the keywords (i.e. `\.` matches any character, but `[\w-_]` should is a more restrictive character set that should match valid variables).
3. Require an assignment operator i.e. `[=:]`.
4. Match the secret contents within either single quotes or double quotes i.e. `('(?:[^'\\]|\\.){6,100}'|"(?:[^"\\]|\\.){6,100}")`. This matches secrets between 6-100 characters that are within opening/closing quotes of the same character. 

As an example the following patterns would be matched:

```
my_apikey = 'test123'
api_key_service      : "test123"
'defaulttoken'  =  "example\"blah''123"
"hidd3n_secret_field":    'unique secret-_120983@£'
```