### PR TITLE
Whitelist default AWS Example keys

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -11,10 +11,18 @@ title = "gitleaks config"
 	regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
 	tags = ["key", "AWS"]
 
+	[[rules.whitelist]]
+		regex = '''AKIAIO5FODNN7EXAMPLE'''
+		description = "ignore example aws key"
+
 [[rules]]
 	description = "AWS Secret Key"
 	regex = '''(?i)aws(.{0,20})?(?-i)['\"][0-9a-zA-Z\/+]{40}['\"]'''
 	tags = ["key", "AWS"]
+
+	[[rules.whitelist]]
+		regex = '''wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'''
+		description = "ignore example aws key"
 
 [[rules]]
 	description = "AWS MWS key"


### PR DESCRIPTION
I noticed that the AWS example key is mentioned in a few places in your docs. But I was curious why this was not whitelisted by default in the tool? I've included a PR for this but I assume you're already not including this for a good reason, so you can close this one if you want, but it would be good to understand why this is.