### PR TITLE
Fix repo-config and file whitelist for AuditUncommitted function

### DIFF
--- a/audit/repo.go
+++ b/audit/repo.go
@@ -104,6 +104,11 @@ func (repo *Repo) AuditUncommitted() error {
 	if err != nil {
 		return err
 	}
+	c.Hash = plumbing.Hash{}
+	c.Message = "STAGED CHANGES"
+	c.Author.Name = ""
+	c.Author.Email = ""
+	c.Author.When = time.Now()
 
 	prevTree, err := c.Tree()
 	if err != nil {
@@ -164,6 +169,7 @@ func (repo *Repo) AuditUncommitted() error {
 					Commit:   c.Hash.String(),
 					Repo:     repo.Name,
 					Rule:     "file regex matched" + repo.config.FileRegex.String(),
+					Message:  c.Message,
 					Author:   c.Author.Name,
 					Email:    c.Author.Email,
 					Date:     c.Author.When,

--- a/audit/repo.go
+++ b/audit/repo.go
@@ -146,18 +146,22 @@ func (repo *Repo) AuditUncommitted() error {
 				}
 			}
 
-			dmp := diffmatchpatch.New()
-			diffs := dmp.DiffMain(prevFileContents, currFileContents, false)
-			var diffContents string
-			for _, d := range diffs {
-				switch d.Type {
-				case diffmatchpatch.DiffInsert:
-					diffContents += fmt.Sprintf("%s\n", d.Text)
-				case diffmatchpatch.DiffDelete:
-					diffContents += fmt.Sprintf("%s\n", d.Text)
+			if fileMatched(filename, repo.config.Whitelist.File) {
+				log.Debugf("whitelisted file found, skipping audit of file: %s", filename)
+			} else {
+				dmp := diffmatchpatch.New()
+				diffs := dmp.DiffMain(prevFileContents, currFileContents, false)
+				var diffContents string
+				for _, d := range diffs {
+					switch d.Type {
+					case diffmatchpatch.DiffInsert:
+						diffContents += fmt.Sprintf("%s\n", d.Text)
+					case diffmatchpatch.DiffDelete:
+						diffContents += fmt.Sprintf("%s\n", d.Text)
+					}
 				}
+				InspectString(diffContents, c, repo, filename)
 			}
-			InspectString(diffContents, c, repo, filename)
 		}
 	}
 

--- a/audit/repo.go
+++ b/audit/repo.go
@@ -104,11 +104,12 @@ func (repo *Repo) AuditUncommitted() error {
 	if err != nil {
 		return err
 	}
+	// Staged change so the commit details do not yet exist. Insert empty defaults.
 	c.Hash = plumbing.Hash{}
-	c.Message = "STAGED CHANGES"
+	c.Message = "***STAGED CHANGES***"
 	c.Author.Name = ""
 	c.Author.Email = ""
-	c.Author.When = time.Now()
+	c.Author.When = time.Unix(0, 0).UTC()
 
 	prevTree, err := c.Tree()
 	if err != nil {

--- a/audit/repo.go
+++ b/audit/repo.go
@@ -157,6 +157,18 @@ func (repo *Repo) AuditUncommitted() error {
 
 			if fileMatched(filename, repo.config.Whitelist.File) {
 				log.Debugf("whitelisted file found, skipping audit of file: %s", filename)
+			} else if fileMatched(filename, repo.config.FileRegex) {
+				repo.Manager.SendLeaks(manager.Leak{
+					Line:     "N/A",
+					Offender: filename,
+					Commit:   c.Hash.String(),
+					Repo:     repo.Name,
+					Rule:     "file regex matched" + repo.config.FileRegex.String(),
+					Author:   c.Author.Name,
+					Email:    c.Author.Email,
+					Date:     c.Author.When,
+					File:     filename,
+				})
 			} else {
 				dmp := diffmatchpatch.New()
 				diffs := dmp.DiffMain(prevFileContents, currFileContents, false)

--- a/audit/repo.go
+++ b/audit/repo.go
@@ -84,6 +84,15 @@ func (repo *Repo) Clone(cloneOption *git.CloneOptions) error {
 // AuditUncommitted will do a `git diff` and scan changed files that are being tracked. This is useful functionality
 // for a pre-commit hook so you can make sure your code does not have any leaks before committing.
 func (repo *Repo) AuditUncommitted() error {
+	// load up alternative config if possible, if not use manager's config
+	if repo.Manager.Opts.RepoConfig {
+		cfg, err := repo.loadRepoConfig()
+		if err != nil {
+			return err
+		}
+		repo.config = cfg
+	}
+
 	auditTimeStart := time.Now()
 
 	r, err := repo.Head()

--- a/test_data/test_local_repo_one_aws_leak_uncommitted.json
+++ b/test_data/test_local_repo_one_aws_leak_uncommitted.json
@@ -5,7 +5,7 @@
   "commit": "0000000000000000000000000000000000000000",
   "repo": "test_repo_1",
   "rule": "AWS Manager ID",
-  "commitMessage": "STAGED CHANGES",
+  "commitMessage": "***STAGED CHANGES***",
   "author": "",
   "email": "",
   "file": "server.test.py",

--- a/test_data/test_local_repo_one_aws_leak_uncommitted.json
+++ b/test_data/test_local_repo_one_aws_leak_uncommitted.json
@@ -2,14 +2,14 @@
  {
   "line": " aws_access_key_id='AKIAIO5FODNN7DXAMPLE'",
   "offender": "AKIAIO5FODNN7DXAMPLE",
-  "commit": "d274003914c707212cbe84e3e466a00013ccb639",
+  "commit": "0000000000000000000000000000000000000000",
   "repo": "test_repo_1",
   "rule": "AWS Manager ID",
-  "commitMessage": "comment\n",
-  "author": "zach rice",
-  "email": "zricer@protonmail.com",
+  "commitMessage": "STAGED CHANGES",
+  "author": "",
+  "email": "",
   "file": "server.test.py",
-  "date": "2019-10-24T10:03:38-04:00",
+  "date": "1970-01-01T00:00:00Z",
   "tags": "key, AWS"
  }
 ]


### PR DESCRIPTION
The audit uncommitted function does not honour the `--repo-config` flag or the `whitelist` file section of the config file. This MR fixes these issues.

I think this fix would be better by refactoring the code base so both audit functions use a single logical function, rather than copying it into 2 different places. I will try and look at this when I get a bit more time. But for now this should be an improvement.