### PR TITLE
Update default whitelist to include gitleaks.toml

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -128,6 +128,6 @@ title = "gitleaks config"
 	tags = ["key", "twilio"]
 
 [whitelist]
-	description = "image whitelists"
-	file = '''(.*?)(jpg|gif|doc|pdf|bin)$'''
+	description = "Whitelisted files"
+	file = '''(^\.?gitleaks.toml$|(.*?)(jpg|gif|doc|pdf|bin)$)'''
 `


### PR DESCRIPTION
Fixes #294 

I think adding this regex `\.?gitleaks.toml$` to the default whitelist is the best way of fixing this. It gives users an opportunity to remote this file from the whitelist in case they ever wanted to do this in the future.

Let me know your thoughts?