### PR TITLE
Adding baseurl flag to allow self-hosted GitLab/GitHub servers

### DIFF
--- a/hosts/github.go
+++ b/hosts/github.go
@@ -27,7 +27,8 @@ type Github struct {
 
 // NewGithubClient accepts a manager struct and returns a Github host pointer which will be used to
 // perform a github audit on an organization, user, or PR.
-func NewGithubClient(m manager.Manager) *Github {
+func NewGithubClient(m manager.Manager) (*Github, error) {
+	var err error
 	ctx := context.Background()
 	token := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: options.GetAccessToken(m.Opts)},
@@ -39,7 +40,6 @@ func NewGithubClient(m manager.Manager) *Github {
 	if m.Opts.BaseURL == "" {
 		githubClient = github.NewClient(httpClient)
 	} else {
-		var err error
 		githubClient, err = github.NewEnterpriseClient(m.Opts.BaseURL, m.Opts.BaseURL, httpClient)
 		if err != nil {
 			log.Error(err)
@@ -49,7 +49,7 @@ func NewGithubClient(m manager.Manager) *Github {
 	return &Github{
 		manager: m,
 		client:  githubClient,
-	}
+	}, err
 }
 
 // Audit will audit a github user or organization's repos.

--- a/hosts/github.go
+++ b/hosts/github.go
@@ -41,9 +41,6 @@ func NewGithubClient(m manager.Manager) (*Github, error) {
 		githubClient = github.NewClient(httpClient)
 	} else {
 		githubClient, err = github.NewEnterpriseClient(m.Opts.BaseURL, m.Opts.BaseURL, httpClient)
-		if err != nil {
-			log.Error(err)
-		}
 	}
 
 	return &Github{

--- a/hosts/github.go
+++ b/hosts/github.go
@@ -33,9 +33,22 @@ func NewGithubClient(m manager.Manager) *Github {
 		&oauth2.Token{AccessToken: options.GetAccessToken(m.Opts)},
 	)
 
+	var githubClient *github.Client
+	httpClient := oauth2.NewClient(ctx, token)
+
+	if m.Opts.BaseURL == "" {
+		githubClient = github.NewClient(httpClient)
+	} else {
+		var err error
+		githubClient, err = github.NewEnterpriseClient(m.Opts.BaseURL, m.Opts.BaseURL, httpClient)
+		if err != nil {
+			log.Error(err)
+		}
+	}
+
 	return &Github{
 		manager: m,
-		client:  github.NewClient(oauth2.NewClient(ctx, token)),
+		client:  githubClient,
 	}
 }
 

--- a/hosts/gitlab.go
+++ b/hosts/gitlab.go
@@ -22,7 +22,9 @@ type Gitlab struct {
 
 // NewGitlabClient accepts a manager struct and returns a Gitlab host pointer which will be used to
 // perform a gitlab audit on an group or user.
-func NewGitlabClient(m manager.Manager) *Gitlab {
+func NewGitlabClient(m manager.Manager) (*Gitlab, error) {
+	var err error
+
 	gitlabClient := &Gitlab{
 		manager: m,
 		ctx:     context.Background(),
@@ -36,7 +38,7 @@ func NewGitlabClient(m manager.Manager) *Gitlab {
 		}
 	}
 
-	return gitlabClient
+	return gitlabClient, err
 }
 
 // Audit will audit a github user or organization's repos.

--- a/hosts/gitlab.go
+++ b/hosts/gitlab.go
@@ -23,11 +23,20 @@ type Gitlab struct {
 // NewGitlabClient accepts a manager struct and returns a Gitlab host pointer which will be used to
 // perform a gitlab audit on an group or user.
 func NewGitlabClient(m manager.Manager) *Gitlab {
-	return &Gitlab{
+	gitlabClient := &Gitlab{
 		manager: m,
 		ctx:     context.Background(),
 		client:  gitlab.NewClient(nil, options.GetAccessToken(m.Opts)),
 	}
+
+	if m.Opts.BaseURL != "" {
+		err := gitlabClient.client.SetBaseURL(m.Opts.BaseURL)
+		if err != nil {
+			log.Error(err)
+		}
+	}
+
+	return gitlabClient
 }
 
 // Audit will audit a github user or organization's repos.

--- a/hosts/gitlab.go
+++ b/hosts/gitlab.go
@@ -32,10 +32,7 @@ func NewGitlabClient(m manager.Manager) (*Gitlab, error) {
 	}
 
 	if m.Opts.BaseURL != "" {
-		err := gitlabClient.client.SetBaseURL(m.Opts.BaseURL)
-		if err != nil {
-			log.Error(err)
-		}
+		err = gitlabClient.client.SetBaseURL(m.Opts.BaseURL)
 	}
 
 	return gitlabClient, err

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -20,11 +20,12 @@ type Host interface {
 // Run kicks off a host audit. This function accepts a manager and determines what host it should audit
 func Run(m *manager.Manager) error {
 	var host Host
+	var err error
 	switch getHost(m.Opts.Host) {
 	case _github:
-		host = NewGithubClient(*m)
+		host, err = NewGithubClient(*m)
 	case _gitlab:
-		host = NewGitlabClient(*m)
+		host, err = NewGitlabClient(*m)
 	default:
 		return nil
 	}
@@ -34,7 +35,7 @@ func Run(m *manager.Manager) error {
 	} else {
 		host.Audit()
 	}
-	return nil
+	return err
 }
 
 func getHost(host string) int {

--- a/options/options.go
+++ b/options/options.go
@@ -52,6 +52,7 @@ type Options struct {
 
 	// Hosts
 	Host         string `long:"host" description:"git hosting service like gitlab or github. Supported hosts include: Github, Gitlab"`
+	BaseURL      string `long:"baseurl" description:"Base URL for API requests. Defaults to the public GitLab or GitHub API, but can be set to a domain endpoint to use with a self hosted server."`
 	Organization string `long:"org" description:"organization to audit"`
 	User         string `long:"user" description:"user to audit"` //work
 	PullRequest  string `long:"pr" description:"pull/merge request url"`


### PR DESCRIPTION
I have tested this with a self-hosted GitLab instance. I have not tested this with a GitHub Enterprise installation, but it *should* work...