### PR TITLE
Add support for PKCS8 key

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -63,7 +63,7 @@ title = "gitleaks config"
 
 [[rules]]
 	description = "Asymmetric Private Key"
-	regex = '''-----BEGIN (EC|PGP|DSA|RSA|OPENSSH) PRIVATE KEY( BLOCK)?-----'''
+	regex = '''-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----'''
 	tags = ["key", "AsymmetricPrivateKey"]
 
 [[rules]]


### PR DESCRIPTION
I see that #296 updated the RegEx used for matching private keys. However, PKCS8 key was forgotten for some reason.

It's present in [v2.1.0 gitleaks.toml](https://github.com/zricethezav/gitleaks/blob/v2.1.0/gitleaks.toml#L24), however.

This PR adds support for PKCS8 keys.