### PR TITLE
Fix empty repo fields when running organization scan

### DIFF
--- a/audit/repo.go
+++ b/audit/repo.go
@@ -74,8 +74,10 @@ func (repo *Repo) Clone(cloneOption *git.CloneOptions) error {
 	if err != nil {
 		return err
 	}
-	repo.Name = filepath.Base(repo.Manager.Opts.Repo)
-	repo.Repository = repository
+    if repo.Manager.Opts.Organization == "" {
+	    repo.Name = filepath.Base(repo.Manager.Opts.Repo)
+    }
+    repo.Repository = repository
 	repo.Manager.RecordTime(manager.CloneTime(howLong(start)))
 
 	return nil


### PR DESCRIPTION
When running organization scan, all values of `repo` field were empty (fille with dot ".") because `repo.Manager.Opts.Repo` was empty. Now when cloning we chck if scan is run for organization and if so, don't set `repo.Name` which is already set correctly. 