### PR TITLE
Repo timeout

### DIFF
--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -213,6 +213,26 @@ func TestAudit(t *testing.T) {
 			},
 			wantEmpty: true,
 		},
+		{
+			description: "test local repo one aws leak timeout",
+			opts: options.Options{
+				RepoPath:     "../test_data/test_repos/test_repo_1",
+				Report:       "../test_data/test_local_repo_one_aws_leak.json.got",
+				ReportFormat: "json",
+				Timeout:      "10ns",
+			},
+			wantEmpty: true,
+		},
+		{
+			description: "test local repo one aws leak long timeout",
+			opts: options.Options{
+				RepoPath:     "../test_data/test_repos/test_repo_1",
+				Report:       "../test_data/test_local_repo_one_aws_leak.json.got",
+				ReportFormat: "json",
+				Timeout:      "2m",
+			},
+			wantPath: "../test_data/test_local_repo_one_aws_leak.json",
+		},
 	}
 
 	for _, test := range tests {

--- a/audit/repo.go
+++ b/audit/repo.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"fmt"
 	"io"
@@ -38,6 +39,8 @@ type Repo struct {
 	// have a gitleaks.toml or .gitleaks.toml config then those configs will be used specifically
 	// for those repo audits.
 	config config.Config
+
+	ctx context.Context
 
 	Name    string
 	Manager *manager.Manager
@@ -200,10 +203,45 @@ func (repo *Repo) AuditUncommitted() error {
 	return nil
 }
 
+// timeoutReached returns true if the timeout deadline has been met. This function should be used
+// at the top of loops and before potentially long running goroutines (like checking inefficient regexes)
+func (repo *Repo) timeoutReached() bool {
+	if repo.ctx.Err() == context.DeadlineExceeded {
+		return true
+	}
+	return false
+}
+
+// setupTimeout parses the --timeout option and assigns a context with timeout to the manager
+// which will exit early if the timeout has been met.
+func (repo *Repo) setupTimeout() error {
+	if repo.Manager.Opts.Timeout == "" {
+		return nil
+	}
+	timeout, err := time.ParseDuration(repo.Manager.Opts.Timeout)
+	if err != nil {
+		return err
+	}
+
+	repo.ctx, _ = context.WithTimeout(context.Background(), timeout)
+
+	go func() {
+		select {
+		case <-repo.ctx.Done():
+			log.Warnf("Timeout deadline exceeded: %s", timeout.String())
+		}
+	}()
+	return nil
+}
+
 // Audit is responsible for scanning the entire history (default behavior) of a
 // git repo. Options that can change the behavior of this function include: --commit, --depth, --branch.
 // See options/options.go for an explanation on these options.
 func (repo *Repo) Audit() error {
+	if err := repo.setupTimeout(); err != nil {
+		return err
+	}
+
 	if repo.Repository == nil {
 		return fmt.Errorf("%s repo is empty", repo.Name)
 	}
@@ -247,7 +285,7 @@ func (repo *Repo) Audit() error {
 	semaphore := make(chan bool, howManyThreads(repo.Manager.Opts.Threads))
 	wg := sync.WaitGroup{}
 	err = cIter.ForEach(func(c *object.Commit) error {
-		if c == nil || c.Hash.String() == repo.Manager.Opts.CommitTo {
+		if c == nil || c.Hash.String() == repo.Manager.Opts.CommitTo || repo.timeoutReached() {
 			return storer.ErrStop
 		}
 
@@ -274,6 +312,9 @@ func (repo *Repo) Audit() error {
 					return
 				}
 			}()
+			if repo.timeoutReached() {
+				return nil
+			}
 			start := time.Now()
 			patch, err := c.Patch(parent)
 			if err != nil {

--- a/options/options.go
+++ b/options/options.go
@@ -32,7 +32,6 @@ type Options struct {
 	Config       string `long:"config" description:"config path"`
 	Disk         bool   `long:"disk" description:"Clones repo(s) to disk"`
 	Version      bool   `long:"version" description:"version number"`
-	Timeout      int    `long:"timeout" description:"Timeout (s)"`
 	Username     string `long:"username" description:"Username for git repo"`
 	Password     string `long:"password" description:"Password for git repo"`
 	AccessToken  string `long:"access-token" description:"Access token for git repo"`
@@ -51,6 +50,7 @@ type Options struct {
 	PrettyPrint  bool   `long:"pretty" description:"Pretty print json if leaks are present"`
 	CommitFrom   string `long:"commit-from" description:"Commit to start audit from"`
 	CommitTo     string `long:"commit-to" description:"Commit to stop audit"`
+	Timeout      string `long:"timeout" description:"Time allowed per audit. Ex: 10us, 30s, 1m, 1h10m1s"`
 
 	// Hosts
 	Host         string `long:"host" description:"git hosting service like gitlab or github. Supported hosts include: Github, Gitlab"`


### PR DESCRIPTION
### Description:
This PR adds a timeout feature via a `--timeout` option. Timeout values must https://golang.org/pkg/time/#ParseDuration compliant. This feature will help with automation of audits and prevent extremely long running audits if desired. Timeout will timeout on a per audit basis, so if you are auditing a github org, the timeout will be applied to each repo in the org.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
