### PR TITLE
exclude-forks gitlab and github

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Application Options:
       --org=           organization to audit
       --user=          user to audit
       --pr=            pull/merge request url
+      --exclude-forks  audit excludes forks
 
 Help Options:
   -h, --help           Show this help message

--- a/hosts/github.go
+++ b/hosts/github.go
@@ -72,7 +72,15 @@ func (g *Github) Audit() {
 			_githubRepos, resp, err = g.client.Repositories.ListByOrg(ctx, g.manager.Opts.Organization,
 				&github.RepositoryListByOrgOptions{ListOptions: listOptions})
 		}
-		githubRepos = append(githubRepos, _githubRepos...)
+
+		for _, r := range _githubRepos {
+			if g.manager.Opts.ExcludeForks && r.GetFork() {
+				log.Debugf("excluding forked repo: %s", *r.Name)
+				continue
+			}
+			githubRepos = append(githubRepos, r)
+		}
+
 
 		if resp == nil {
 			break

--- a/hosts/gitlab.go
+++ b/hosts/gitlab.go
@@ -57,19 +57,26 @@ func (g *Gitlab) Audit() {
 			glOpts := &gitlab.ListProjectsOptions{
 				ListOptions: listOpts,
 			}
-			projects, resp, err = g.client.Projects.ListUserProjects(g.manager.Opts.User, glOpts)
+			_projects, resp, err = g.client.Projects.ListUserProjects(g.manager.Opts.User, glOpts)
 
 		} else if g.manager.Opts.Organization != "" {
 			glOpts := &gitlab.ListGroupProjectsOptions{
 				ListOptions: listOpts,
 			}
-			projects, resp, err = g.client.Groups.ListGroupProjects(g.manager.Opts.Organization, glOpts)
+			_projects, resp, err = g.client.Groups.ListGroupProjects(g.manager.Opts.Organization, glOpts)
 		}
 		if err != nil {
 			log.Error(err)
 		}
 
-		projects = append(projects, _projects...)
+		for _, p := range _projects {
+			if g.manager.Opts.ExcludeForks && p.ForkedFromProject != nil {
+				log.Debugf("excluding forked repo: %s", p.Name)
+				continue
+			}
+			projects = append(projects, p)
+		}
+
 		if resp == nil {
 			break
 		}

--- a/options/options.go
+++ b/options/options.go
@@ -56,8 +56,9 @@ type Options struct {
 	Host         string `long:"host" description:"git hosting service like gitlab or github. Supported hosts include: Github, Gitlab"`
 	BaseURL      string `long:"baseurl" description:"Base URL for API requests. Defaults to the public GitLab or GitHub API, but can be set to a domain endpoint to use with a self hosted server."`
 	Organization string `long:"org" description:"organization to audit"`
-	User         string `long:"user" description:"user to audit"` //work
+	User         string `long:"user" description:"user to audit"`
 	PullRequest  string `long:"pr" description:"pull/merge request url"`
+	ExcludeForks bool   `long:"exclude-forks" description:"audit excludes forks"`
 }
 
 // ParseOptions is responsible for parsing options passed in by cli. An Options struct


### PR DESCRIPTION
### Description:
Adds the `exclude-fork` option. If auditing against a git host like gitlab or github the audit will exclude forks from the organization/user/group.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
