### PR TITLE
Adding timeout check in context select so we dont log erroneously

### DIFF
--- a/audit/repo.go
+++ b/audit/repo.go
@@ -391,7 +391,9 @@ func (repo *Repo) setupTimeout() error {
 	go func() {
 		select {
 		case <-repo.ctx.Done():
-			log.Warnf("Timeout deadline (%s) exceeded for %s", timeout.String(), repo.Name)
+			if repo.timeoutReached() {
+				log.Warnf("Timeout deadline (%s) exceeded for %s", timeout.String(), repo.Name)
+			}
 		}
 	}()
 	return nil


### PR DESCRIPTION
### Description:
While using gitleaks in another program I noticed I was getting additional timeout warnings when timeout was set. This fixes that

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
