### PR TITLE
Fixed bug where the repo name was removed on a user or org audit.

### DIFF
--- a/hosts/github.go
+++ b/hosts/github.go
@@ -99,10 +99,10 @@ func (g *Github) Audit() {
 
 	for _, repo := range githubRepos {
 		r := audit.NewRepo(g.manager)
-		r.Name = *repo.Name
 		err := r.Clone(&git.CloneOptions{
 			URL: *repo.CloneURL,
 		})
+		r.Name = *repo.Name
 		if err != nil {
 			log.Warn("unable to clone via https and access token, attempting with ssh now")
 			auth, err := options.SSHAuth(g.manager.Opts)


### PR DESCRIPTION
### Description:
Fixes Issue #335. The Repo.Name field is removed during a clone if the '--repo' argument is missing, which happens when scanning a user or organization. This was fixed by setting the name _after_ the clone in hosts/github.go. This is the same pattern that's used in hosts/gitlab.go.