### PR TITLE
fixing issue #367

### DIFF
--- a/audit/util.go
+++ b/audit/util.go
@@ -132,11 +132,6 @@ func ruleContainFilePathRegex(rule config.Rule) bool {
 }
 
 func sendLeak(offender string, line string, filename string, rule config.Rule, c *object.Commit, repo *Repo) {
-	if repo.Manager.Opts.Redact {
-		line = strings.ReplaceAll(line, offender, "REDACTED")
-		offender = "REDACTED"
-	}
-
 	repo.Manager.SendLeaks(manager.Leak{
 		Line:     line,
 		Offender: offender,

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"sync"
 	"text/tabwriter"
 	"time"
@@ -158,6 +159,10 @@ func (manager *Manager) SendLeaks(l Leak) {
 	h := sha1.New()
 	h.Write([]byte(l.Commit + l.Offender + l.File + l.Line))
 	l.lookupHash = hex.EncodeToString(h.Sum(nil))
+	if manager.Opts.Redact {
+		l.Line = strings.ReplaceAll(l.Line, l.Offender, "REDACTED")
+		l.Offender = "REDACTED"
+	}
 	manager.leakWG.Add(1)
 	manager.leakChan <- l
 }


### PR DESCRIPTION
### Description:

This PR fix an issue regarding the `--redact` option ( #332 #367 ). 
Because the SHA1 fingerprint was calculated after the line is redacted, some similar (but different) lines had the same fingerprint after the "secret" was redacted.

Example:

'django.contrib.auth.password_validation.MinimumLengthValidator'
'django.contrib.auth.password_validation.CommonPasswordValidator'

were both redacted to: 'django.contrib.auth.REDACTED' and as this string is used to calculate a fingerprint to have "unique" findings, the results were incorrect.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
