### PR TITLE
Whitelist files not being parsed

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -138,5 +138,5 @@ title = "gitleaks config"
 
 [whitelist]
 	description = "Whitelisted files"
-	file = '''(^\.?gitleaks.toml$|(.*?)(jpg|gif|doc|pdf|bin)$)'''
+	files = [ '''(^\.?gitleaks.toml$|(.*?)(jpg|gif|doc|pdf|bin)$)''' ]
 `


### PR DESCRIPTION
It seems that there is a typo on the default rules.

### Description:
It seems that the default whitelist rules are not parsed since the struct expects **Files       []*regexp.Regexp**

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
