### PR TITLE
Add redact-pi flag to redact personal data.

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -163,6 +163,12 @@ func (manager *Manager) SendLeaks(l Leak) {
 		l.Line = strings.ReplaceAll(l.Line, l.Offender, "REDACTED")
 		l.Offender = "REDACTED"
 	}
+	if manager.Opts.RedactPersonalInfo {
+		l.Line = strings.ReplaceAll(l.Line, l.Author, "REDACTED")
+		l.Line = strings.ReplaceAll(l.Line, l.Email, "REDACTED")
+		l.Author = "REDACTED"
+		l.Email = "REDACTED"
+	}
 	manager.leakWG.Add(1)
 	manager.leakChan <- l
 }

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -43,6 +43,25 @@ func TestSendReceiveLeaks(t *testing.T) {
 	}
 }
 
+func TestRedactPI(t *testing.T) {
+	opts := options.Options{RedactPersonalInfo: true}
+	cfg, _ := config.NewConfig(opts)
+	m, _ := NewManager(opts, cfg)
+
+	m.SendLeaks(Leak{Offender: newUUID(), Author: "John Doe", Email: "john.doe@..."})
+	m.SendLeaks(Leak{Offender: newUUID(), Author: "Jane Doe", Email: "jane.doe@..."})
+
+	leaks := m.GetLeaks()
+	for _, leak := range leaks {
+		if leak.Author != "REDACTED" {
+			t.Errorf("got author '%s', wanted 'REDACTED'", leak.Author)
+		}
+		if leak.Email != "REDACTED" {
+			t.Errorf("got email '%s', wanted 'REDACTED'", leak.Email)
+		}
+	}
+}
+
 func TestSendReceiveMeta(t *testing.T) {
 	tests := []struct {
 		auditTime  int64

--- a/options/options.go
+++ b/options/options.go
@@ -28,34 +28,35 @@ const (
 
 // Options stores values of command line options
 type Options struct {
-	Verbose       bool   `short:"v" long:"verbose" description:"Show verbose output from audit"`
-	Repo          string `short:"r" long:"repo" description:"Target repository"`
-	Config        string `long:"config" description:"config path"`
-	Disk          bool   `long:"disk" description:"Clones repo(s) to disk"`
-	Version       bool   `long:"version" description:"version number"`
-	Username      string `long:"username" description:"Username for git repo"`
-	Password      string `long:"password" description:"Password for git repo"`
-	AccessToken   string `long:"access-token" description:"Access token for git repo"`
-	Commit        string `long:"commit" description:"sha of commit to audit or \"latest\" to scan the last commit of the repository"`
-	FilesAtCommit string `long:"files-at-commit" description:"sha of commit to audit all files at commit"`
-	Threads       int    `long:"threads" description:"Maximum number of threads gitleaks spawns"`
-	SSH           string `long:"ssh-key" description:"path to ssh key used for auth"`
-	Uncommited    bool   `long:"uncommitted" description:"run gitleaks on uncommitted code"`
-	RepoPath      string `long:"repo-path" description:"Path to repo"`
-	OwnerPath     string `long:"owner-path" description:"Path to owner directory (repos discovered)"`
-	Branch        string `long:"branch" description:"Branch to audit"`
-	Report        string `long:"report" description:"path to write json leaks file"`
-	ReportFormat  string `long:"report-format" default:"json" description:"json or csv"`
-	Redact        bool   `long:"redact" description:"redact secrets from log messages and leaks"`
-	Debug         bool   `long:"debug" description:"log debug messages"`
-	RepoConfig    bool   `long:"repo-config" description:"Load config from target repo. Config file must be \".gitleaks.toml\" or \"gitleaks.toml\""`
-	PrettyPrint   bool   `long:"pretty" description:"Pretty print json if leaks are present"`
-	CommitFrom    string `long:"commit-from" description:"Commit to start audit from"`
-	CommitTo      string `long:"commit-to" description:"Commit to stop audit"`
-	CommitSince   string `long:"commit-since" description:"Audit commits more recent than a specific date. Ex: '2006-01-02' or '2006-01-02T15:04:05-0700' format."`
-	CommitUntil   string `long:"commit-until" description:"Audit commits older than a specific date. Ex: '2006-01-02' or '2006-01-02T15:04:05-0700' format."`
-	Timeout       string `long:"timeout" description:"Time allowed per audit. Ex: 10us, 30s, 1m, 1h10m1s"`
-	Depth         int    `long:"depth" description:"Number of commits to audit"`
+	Verbose            bool   `short:"v" long:"verbose" description:"Show verbose output from audit"`
+	Repo               string `short:"r" long:"repo" description:"Target repository"`
+	Config             string `long:"config" description:"config path"`
+	Disk               bool   `long:"disk" description:"Clones repo(s) to disk"`
+	Version            bool   `long:"version" description:"version number"`
+	Username           string `long:"username" description:"Username for git repo"`
+	Password           string `long:"password" description:"Password for git repo"`
+	AccessToken        string `long:"access-token" description:"Access token for git repo"`
+	Commit             string `long:"commit" description:"sha of commit to audit or \"latest\" to scan the last commit of the repository"`
+	FilesAtCommit      string `long:"files-at-commit" description:"sha of commit to audit all files at commit"`
+	Threads            int    `long:"threads" description:"Maximum number of threads gitleaks spawns"`
+	SSH                string `long:"ssh-key" description:"path to ssh key used for auth"`
+	Uncommited         bool   `long:"uncommitted" description:"run gitleaks on uncommitted code"`
+	RepoPath           string `long:"repo-path" description:"Path to repo"`
+	OwnerPath          string `long:"owner-path" description:"Path to owner directory (repos discovered)"`
+	Branch             string `long:"branch" description:"Branch to audit"`
+	Report             string `long:"report" description:"path to write json leaks file"`
+	ReportFormat       string `long:"report-format" default:"json" description:"json or csv"`
+	RedactPersonalInfo bool   `long:"redact-pi" description:"redact usernames and email from results"`
+	Redact             bool   `long:"redact" description:"redact secrets from log messages and leaks"`
+	Debug              bool   `long:"debug" description:"log debug messages"`
+	RepoConfig         bool   `long:"repo-config" description:"Load config from target repo. Config file must be \".gitleaks.toml\" or \"gitleaks.toml\""`
+	PrettyPrint        bool   `long:"pretty" description:"Pretty print json if leaks are present"`
+	CommitFrom         string `long:"commit-from" description:"Commit to start audit from"`
+	CommitTo           string `long:"commit-to" description:"Commit to stop audit"`
+	CommitSince        string `long:"commit-since" description:"Audit commits more recent than a specific date. Ex: '2006-01-02' or '2006-01-02T15:04:05-0700' format."`
+	CommitUntil        string `long:"commit-until" description:"Audit commits older than a specific date. Ex: '2006-01-02' or '2006-01-02T15:04:05-0700' format."`
+	Timeout            string `long:"timeout" description:"Time allowed per audit. Ex: 10us, 30s, 1m, 1h10m1s"`
+	Depth              int    `long:"depth" description:"Number of commits to audit"`
 
 	// Hosts
 	Host         string `long:"host" description:"git hosting service like gitlab or github. Supported hosts include: Github, Gitlab"`


### PR DESCRIPTION
### Description:
Adds new flag to redact personal data (author names and email) from generated reports.
This is specially handy when reports are automatically ingested into other applications which do not need/want to store personal information.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
