### PR TITLE
Clean up 'uncommitted' diff.

### DIFF
--- a/scan/scan.go
+++ b/scan/scan.go
@@ -281,7 +281,8 @@ func (repo *Repo) scanUncommitted() error {
 				}
 			}
 
-			diffs := diffmatchpatch.New().DiffMain(prevFileContents, currFileContents, false)
+			dmp := diffmatchpatch.New()
+			diffs := dmp.DiffCleanupSemantic(dmp.DiffMain(prevFileContents, currFileContents, false))
 			var diffContents string
 			for _, d := range diffs {
 				if d.Type == diffmatchpatch.DiffInsert {


### PR DESCRIPTION
### Description:
This PR fixes an issue originating in how go-diff is used on uncommitted changes.

Given the following git diff:
```git
diff --git a/.ci/ci.settings.xml b/.ci/ci.settings.xml
index ec2cf0ac76..bd029dd740 100644
--- a/.ci/ci.settings.xml
+++ b/.ci/ci.settings.xml
@@ -13,7 +13,9 @@
         <server>
             <id>foo-bar</id>
             <username>${env.S3_KEY_ID}</username>
-            <password>${env.S3_SECRET}</password>
+            <password>
+-----BEGIN EC PRIVATE KEY-----
+            </password>
         </server>
         <server>
             <id>bar-baz</id>
```

On current master, `diffContents` at https://github.com/zricethezav/gitleaks/blob/master/scan/scan.go#L291 contains the following string (note the line breaks):
```
\n-----BEGIN \n P\nIVA\nE KEY-----\n            \n
```
The problem with this is, that standard and custom regexes do not produce matches and pre-commit hooks therefore result in false negatives.

According to https://github.com/sergi/go-diff/issues/91, `DiffCleanupSemantic` has to be used to have a diff respecting line boundaries and producing more git like diffs.

With this PR applied, `diffContents` at the same place contains the following string, which will also match against regexes:
```
\n-----BEGIN EC PRIVATE KEY-----\n            \n
```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
