### PR TITLE
Add feature to scan a GitLab commit through a commit link

### DIFF
--- a/hosts/github.go
+++ b/hosts/github.go
@@ -188,3 +188,8 @@ func (g *Github) ScanPR() {
 		}
 	}
 }
+
+// ScanCommitURL scan a single github commit link url
+func (g *Github) ScanCommitURL() {
+	log.Error("ScanCommitURL is not implemented in GitHub host yet...")
+}

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -16,6 +16,7 @@ const (
 type Host interface {
 	Scan()
 	ScanPR()
+	ScanCommitURL()
 }
 
 // Run kicks off a host scan. This function accepts a manager and determines what host it should scan
@@ -37,6 +38,8 @@ func Run(m *manager.Manager) error {
 
 	if m.Opts.PullRequest != "" {
 		host.ScanPR()
+	} else if m.Opts.CommitURL != "" {
+		host.ScanCommitURL()
 	} else {
 		host.Scan()
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -64,6 +64,7 @@ type Options struct {
 	Organization string `long:"org" description:"organization to scan"`
 	User         string `long:"user" description:"user to scan"`
 	PullRequest  string `long:"pr" description:"pull/merge request url"`
+	CommitURL    string `long:"commit-url" description:"commit url"`
 	ExcludeForks bool   `long:"exclude-forks" description:"scan excludes forks"`
 }
 


### PR DESCRIPTION
### Description:
This PR adds a feature to allow scanning of a commit diff in GitLab through the commit link.

The commit link can be in one of two formats:
1. https://gitlab.com/gitlab-org/gitlab/-/commit/39264445dde9de4772e57bfaf368fc69b8942d53
2. https://gitlab.com/gitlab-org/gitlab/commit/39264445dde9de4772e57bfaf368fc69b8942d53 

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
