### PR TITLE
scan: fix dropped errors

### DIFF
--- a/scan/repo.go
+++ b/scan/repo.go
@@ -201,6 +201,10 @@ func getLogOptions(repo *Repo) (*git.LogOptions, error) {
 			}
 			return nil
 		})
+		if err != nil {
+			return nil, err
+		}
+
 		if logOpts.From.IsZero() {
 			return nil, fmt.Errorf("could not find branch %s", repo.Manager.Opts.Branch)
 		}
@@ -259,6 +263,10 @@ func (repo *Repo) loadRepoConfig() (config.Config, error) {
 	defer f.Close()
 	var tomlLoader config.TomlLoader
 	_, err = toml.DecodeReader(f, &tomlLoader)
+	if err != nil {
+		return config.Config{}, err
+	}
+
 	return tomlLoader.Parse()
 }
 

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -175,6 +175,9 @@ func (repo *Repo) scanEmpty() error {
 	}
 
 	status, err := wt.Status()
+	if err != nil {
+		return err
+	}
 	for fn := range status {
 		workTreeBuf := bytes.NewBuffer(nil)
 		workTreeFile, err := wt.Filesystem.Open(fn)

--- a/scan/scan_test.go
+++ b/scan/scan_test.go
@@ -422,6 +422,9 @@ func TestScan(t *testing.T) {
 		}
 
 		err = m.Report()
+		if err != nil {
+			t.Error(err)
+		}
 
 		if test.wantEmpty {
 			if len(m.GetLeaks()) != 0 {


### PR DESCRIPTION
This fixes some dropped `err` variables in the `scan` package.