### PR TITLE
Adding some logic to fix line number extractor when there are multipl…

### DIFF
--- a/scan/rule.go
+++ b/scan/rule.go
@@ -24,6 +24,7 @@ const (
 	diffAddFilePrefix      = "+++ b"
 	diffAddFilePrefixSlash = "+++ b/"
 	diffLineSignature      = " @@"
+	diffLineSignaturePrefix      = "@@ "
 	defaultLineNumber      = -1
 )
 
@@ -238,6 +239,16 @@ func extractAndInjectLineNumber(leak *manager.Leak, bundle *Bundle, repo *Repo) 
 					leak.LineNumber = potentialLine
 					return
 				}
+			} else if strings.HasPrefix(txt, diffLineSignaturePrefix) && currStartDiffLine != 0 {
+				// This logic is used for when there are multiple leaks of the same offender within the same patch
+				i := strings.Index(txt, diffAddPrefix)
+				pairs := strings.Split(strings.Split(txt[i+1:], diffLineSignature)[0], ",")
+				currStartDiffLine, err = strconv.Atoi(pairs[0])
+				if err != nil {
+					log.Debug(err)
+					return
+				}
+				currLine = 0
 			}
 			currLine++
 		}

--- a/scan/rule.go
+++ b/scan/rule.go
@@ -20,12 +20,12 @@ import (
 )
 
 const (
-	diffAddPrefix          = "+"
-	diffAddFilePrefix      = "+++ b"
-	diffAddFilePrefixSlash = "+++ b/"
-	diffLineSignature      = " @@"
-	diffLineSignaturePrefix      = "@@ "
-	defaultLineNumber      = -1
+	diffAddPrefix           = "+"
+	diffAddFilePrefix       = "+++ b"
+	diffAddFilePrefixSlash  = "+++ b/"
+	diffLineSignature       = " @@"
+	diffLineSignaturePrefix = "@@ "
+	defaultLineNumber       = -1
 )
 
 // CheckRules accepts bundle and checks each rule defined in the config against the bundle's content.


### PR DESCRIPTION
Example patch:
```
diff --git a/main.php b/main.php
index 6bed0010f104b67ec72351f0908c9c8f75bda85b..9348c004a554b549a6913631f2132c01ad2d8148 100644
--- a/main.php
+++ b/main.php
@@ -8,14 +8,15 @@
 const EMPTYSTR string = ""
 const AUTH = "ES_AUTH:2a5:retbe"
 const AWS_ID = "AKIAIOSFODNN7EXAMPLE"
+
+const AWS_ID = "AKIAIOSFODNN7EXAMPLE"
+
 const AWS_KEY = ""
 const WORDPRESS = ""
 const HEROKU_KEY = ""
 const SSHKEY = `-----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED

-
-const AWS_ID = "AKIAIOSFODNN7EXAMPLE"
 
 
 PxyzMAlAmEu/Qkx9nPh696SU7/MjXpCpOnfFiijLhJumNcRlWgsOiI9rfwlkh4aN
@@ -57,6 +58,7 @@ var opts *Options
 
 func main() {
        args := os.Args[1:]
+    AWS_ID := "AKIAIOSFODNN7EXAMPLE"
 
        db, err := setupDB()
        if err != nil {

```

This PR fixes a bug where the line reported for the `+    AWS_ID := "AKIAIOSFODNN7EXAMPLE"` leak would be `29`. I added some additional logic to check for additional diff additions/deletions within the context of the same patch. Prior to this PR the line extraction code would detect the "starting diff line" as line 15 per  `@@ -8,14 +8,15 @@`, which means that second leak, `+    AWS_ID := "AKIAIOSFODNN7EXAMPLE"` would have the wrong starting offset. With this MR I put in some code to detect that second diff addition/deletion line, `@@ -57,6 +58,7 @@ var opts *Options` which fixes this bug

### Description:
Explain the purpose of the PR.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
