### PR TITLE
Add tilde and relative path support for local repo scan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hako/durafmt v0.0.0-20191009132224-3f39dc1ed9f4
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-colorable v0.1.2
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sergi/go-diff v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/xanzy/go-gitlab v0.21.0

--- a/options/options.go
+++ b/options/options.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/jessevdk/go-flags"
 	log "github.com/sirupsen/logrus"
+        homedir "github.com/mitchellh/go-homedir"
 )
 
 // No leaks or early exit due to invalid options
@@ -97,6 +98,16 @@ func ParseOptions() (Options, error) {
 		}
 		os.Exit(Success)
 	}
+
+	opts.RepoPath, err = homedir.Expand(opts.RepoPath)
+        if err != nil {
+                log.Error(err)
+        }
+
+	opts.OwnerPath, err = homedir.Expand(opts.OwnerPath)
+        if err != nil {
+                log.Error(err)
+        }
 
 	if opts.Debug {
 		log.SetLevel(log.DebugLevel)


### PR DESCRIPTION
### Description:

Currently only absolute paths work with local repo scan using **--repopath** and  **--ownerpath**.

```
gitleaks --repo-path=/home/doe/TEST/iNaturalist-Observations/
INFO[2020-09-06T23:33:44+05:30] No leaks detected. 3 commits scanned in 9 milliseconds 892 microseconds 

gitleaks --owner-path=/home/doe/per/TEST/
WARN[2020-09-06T23:34:14+05:30] abc is not a git repo, skipping             
WARN[2020-09-06T23:34:14+05:30] def is not a git repo, skipping       
INFO[2020-09-06T23:34:14+05:30] No leaks detected. 3 commits scanned in 7 milliseconds 224 microseconds 

gitleaks --repo-path=~/per/TEST/iNaturalist-Observations/
ERRO[2020-09-06T23:33:57+05:30] repository does not exist      

gitleaks --owner-path=~/per/TEST/
ERRO[2020-09-06T23:34:05+05:30] open ~/per/TEST/: no such file or directory 
```              
This patch enables support for tilde and relative path.  

