### PR TITLE
Update default.go

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -23,12 +23,12 @@ title = "gitleaks config"
 
 [[rules]]
 	description = "Facebook Secret Key"
-	regex = '''(?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}['\"]'''
+	regex = '''(?i)([^0-9a-z])(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}['\"]'''
 	tags = ["key", "Facebook"]
 
 [[rules]]
 	description = "Facebook Client ID"
-	regex = '''(?i)(facebook|fb)(.{0,20})?['\"][0-9]{13,17}['\"]'''
+	regex = '''(?i)([^0-9a-z])(facebook|fb)(.{0,20})?['\"][0-9]{13,17}['\"]'''
 	tags = ["key", "Facebook"]
 
 [[rules]]


### PR DESCRIPTION
the regex for facebook ID and Secret Keys finds any fb followed by something followed by a 32 HEX string.
This recognizes ONTOML identifiers as well used in the XML representation of eclass models.

My proposed change would request that there is not HEX value before the fb or facebook which essentially means that the fb should not be part of a larger HEX string itself.

### Description:
Explain the purpose of the PR.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
