### PR TITLE
Enable allowlisting of repositories taken from a GitHub/GitLab user or org.

### DIFF
--- a/hosts/github.go
+++ b/hosts/github.go
@@ -131,6 +131,10 @@ func (g *Github) Scan() {
 				continue
 			}
 		}
+		if r.IsAllowListed() {
+			log.Infof("repo %s is allowlisted. skipping scan.", r.Name)
+			continue
+		}
 		if err = r.Scan(); err != nil {
 			log.Warn(err)
 		}

--- a/hosts/gitlab.go
+++ b/hosts/gitlab.go
@@ -100,6 +100,10 @@ func (g *Gitlab) Scan() {
 		// TODO handle clone retry with ssh like github host
 		r.Name = p.Name
 
+		if r.IsAllowListed() {
+			log.Infof("repo %s is allowlisted. skipping scan.", r.Name)
+			continue
+		}
 		if err = r.Scan(); err != nil {
 			log.Error(err)
 		}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -260,7 +260,6 @@ func (manager *Manager) DebugOutput() {
 
 }
 
-
 func (manager *Manager) receiveInterrupt() {
 	<-manager.stopChan
 	if manager.Opts.Report != "" {

--- a/manager/report.go
+++ b/manager/report.go
@@ -75,4 +75,3 @@ func (manager *Manager) Report() error {
 	}
 	return nil
 }
-

--- a/manager/sarif.go
+++ b/manager/sarif.go
@@ -24,8 +24,8 @@ type FullDescription struct {
 
 //Rules ...
 type Rules struct {
-	ID         string          `json:"id"`
-	Name       string          `json:"name"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 //Driver ...
@@ -135,8 +135,7 @@ func (manager *Manager) leaksToResults() []Results {
 func leakToLocation(leak Leak) []Locations {
 	return []Locations{
 		{
-			PhysicalLocation:
-			PhysicalLocation{
+			PhysicalLocation: PhysicalLocation{
 				ArtifactLocation: ArtifactLocation{
 					URI: leak.File,
 				},
@@ -150,4 +149,3 @@ func leakToLocation(leak Leak) []Locations {
 		},
 	}
 }
-

--- a/options/options.go
+++ b/options/options.go
@@ -28,27 +28,27 @@ const (
 
 // Options stores values of command line options
 type Options struct {
-	Verbose         bool   `short:"v" long:"verbose" description:"Show verbose output from scan"`
-	Repo            string `short:"r" long:"repo" description:"Target repository"`
-	Config          string `long:"config" description:"config path"`
-	Disk            bool   `long:"disk" description:"Clones repo(s) to disk"`
-	Version         bool   `long:"version" description:"version number"`
-	Username        string `long:"username" description:"Username for git repo"`
-	Password        string `long:"password" description:"Password for git repo"`
-	AccessToken     string `long:"access-token" description:"Access token for git repo"`
-	FilesAtCommit   string `long:"files-at-commit" description:"sha of commit to scan all files at commit"`
-	Threads         int    `long:"threads" description:"Maximum number of threads gitleaks spawns"`
-	SSH             string `long:"ssh-key" description:"path to ssh key used for auth"`
-	Uncommited      bool   `long:"uncommitted" description:"run gitleaks on uncommitted code"`
-	RepoPath        string `long:"repo-path" description:"Path to repo"`
-	OwnerPath       string `long:"owner-path" description:"Path to owner directory (repos discovered)"`
-	Branch          string `long:"branch" description:"Branch to scan"`
-	Report          string `long:"report" description:"path to write json leaks file"`
-	ReportFormat    string `long:"report-format" default:"json" description:"json, csv, sarif"`
-	Redact          bool   `long:"redact" description:"redact secrets from log messages and leaks"`
-	Debug           bool   `long:"debug" description:"log debug messages"`
-	RepoConfig      bool   `long:"repo-config" description:"Load config from target repo. Config file must be \".gitleaks.toml\" or \"gitleaks.toml\""`
-	PrettyPrint     bool   `long:"pretty" description:"Pretty print json if leaks are present"`
+	Verbose       bool   `short:"v" long:"verbose" description:"Show verbose output from scan"`
+	Repo          string `short:"r" long:"repo" description:"Target repository"`
+	Config        string `long:"config" description:"config path"`
+	Disk          bool   `long:"disk" description:"Clones repo(s) to disk"`
+	Version       bool   `long:"version" description:"version number"`
+	Username      string `long:"username" description:"Username for git repo"`
+	Password      string `long:"password" description:"Password for git repo"`
+	AccessToken   string `long:"access-token" description:"Access token for git repo"`
+	FilesAtCommit string `long:"files-at-commit" description:"sha of commit to scan all files at commit"`
+	Threads       int    `long:"threads" description:"Maximum number of threads gitleaks spawns"`
+	SSH           string `long:"ssh-key" description:"path to ssh key used for auth"`
+	Uncommited    bool   `long:"uncommitted" description:"run gitleaks on uncommitted code"`
+	RepoPath      string `long:"repo-path" description:"Path to repo"`
+	OwnerPath     string `long:"owner-path" description:"Path to owner directory (repos discovered)"`
+	Branch        string `long:"branch" description:"Branch to scan"`
+	Report        string `long:"report" description:"path to write json leaks file"`
+	ReportFormat  string `long:"report-format" default:"json" description:"json, csv, sarif"`
+	Redact        bool   `long:"redact" description:"redact secrets from log messages and leaks"`
+	Debug         bool   `long:"debug" description:"log debug messages"`
+	RepoConfig    bool   `long:"repo-config" description:"Load config from target repo. Config file must be \".gitleaks.toml\" or \"gitleaks.toml\""`
+	PrettyPrint   bool   `long:"pretty" description:"Pretty print json if leaks are present"`
 
 	// Commit Options
 	Commit      string `long:"commit" description:"sha of commit to scan or \"latest\" to scan the last commit of the repository"`
@@ -59,9 +59,9 @@ type Options struct {
 	CommitSince string `long:"commit-since" description:"Scan commits more recent than a specific date. Ex: '2006-01-02' or '2006-01-02T15:04:05-0700' format."`
 	CommitUntil string `long:"commit-until" description:"Scan commits older than a specific date. Ex: '2006-01-02' or '2006-01-02T15:04:05-0700' format."`
 
-	Timeout         string `long:"timeout" description:"Time allowed per scan. Ex: 10us, 30s, 1m, 1h10m1s"`
-	Depth           int    `long:"depth" description:"Number of commits to scan"`
-	Deletion        bool   `long:"include-deletion" description:"Scan for patch deletions in addition to patch additions"`
+	Timeout  string `long:"timeout" description:"Time allowed per scan. Ex: 10us, 30s, 1m, 1h10m1s"`
+	Depth    int    `long:"depth" description:"Number of commits to scan"`
+	Deletion bool   `long:"include-deletion" description:"Scan for patch deletions in addition to patch additions"`
 
 	// Hosts
 	Host         string `long:"host" description:"git hosting service like gitlab or github. Supported hosts include: Github, Gitlab"`

--- a/options/options.go
+++ b/options/options.go
@@ -110,10 +110,10 @@ func ParseOptions() (Options, error) {
 // else nil is returned
 func (opts Options) Guard() error {
 	if !oneOrNoneSet(opts.Repo, opts.OwnerPath, opts.RepoPath, opts.Host) {
-		return fmt.Errorf("only one target option must can be set. target options: repo, owner-path, repo-path, host")
+		return fmt.Errorf("only one target option can be set. target options: repo, owner-path, repo-path, host")
 	}
 	if !oneOrNoneSet(opts.Organization, opts.User, opts.PullRequest) {
-		return fmt.Errorf("only one target option must can be set. target options: repo, owner-path, repo-path, host")
+		return fmt.Errorf("only one target option can be set. target options: org, user, pr")
 	}
 	if !oneOrNoneSet(opts.AccessToken, opts.Password) {
 		log.Warn("both access-token and password are set. Only password will be attempted")

--- a/scan/repo.go
+++ b/scan/repo.go
@@ -80,14 +80,6 @@ func runHelper(r *Repo) error {
 	if r.IsAllowListed() {
 		return nil
 	}
-	for _, allowListedRepo := range r.Manager.Config.Allowlist.Repos {
-		if RegexMatched(r.Manager.Opts.RepoPath, allowListedRepo) {
-			return nil
-		}
-		if RegexMatched(r.Manager.Opts.Repo, allowListedRepo) {
-			return nil
-		}
-	}
 	if r.Manager.Opts.OpenLocal() {
 		r.Name = path.Base(r.Manager.Opts.RepoPath)
 		if err := r.Open(); err != nil {


### PR DESCRIPTION
Addresses bug #427.

### Description:
This PR allows one to ignore single repositories from a GitHub/GitLab user or org through the global allowlist config called `repos`.

A dedicated GitHub integration test was added. 
Please note that an existing integration test did not pass.

GitLab integration was not tested due to a lack of available repositories.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
