### PR TITLE
Added feature to search gitlab groups recursively

### DIFF
--- a/hosts/gitlab.go
+++ b/hosts/gitlab.go
@@ -61,7 +61,8 @@ func (g *Gitlab) Scan() {
 
 		} else if g.manager.Opts.Organization != "" {
 			glOpts := &gitlab.ListGroupProjectsOptions{
-				ListOptions: listOpts,
+				ListOptions:      listOpts,
+				IncludeSubgroups: &g.manager.Opts.Recursive,
 			}
 			_projects, resp, err = g.client.Groups.ListGroupProjects(g.manager.Opts.Organization, glOpts)
 		}

--- a/options/options.go
+++ b/options/options.go
@@ -28,27 +28,27 @@ const (
 
 // Options stores values of command line options
 type Options struct {
-	Verbose         bool   `short:"v" long:"verbose" description:"Show verbose output from scan"`
-	Repo            string `short:"r" long:"repo" description:"Target repository"`
-	Config          string `long:"config" description:"config path"`
-	Disk            bool   `long:"disk" description:"Clones repo(s) to disk"`
-	Version         bool   `long:"version" description:"version number"`
-	Username        string `long:"username" description:"Username for git repo"`
-	Password        string `long:"password" description:"Password for git repo"`
-	AccessToken     string `long:"access-token" description:"Access token for git repo"`
-	FilesAtCommit   string `long:"files-at-commit" description:"sha of commit to scan all files at commit"`
-	Threads         int    `long:"threads" description:"Maximum number of threads gitleaks spawns"`
-	SSH             string `long:"ssh-key" description:"path to ssh key used for auth"`
-	Uncommited      bool   `long:"uncommitted" description:"run gitleaks on uncommitted code"`
-	RepoPath        string `long:"repo-path" description:"Path to repo"`
-	OwnerPath       string `long:"owner-path" description:"Path to owner directory (repos discovered)"`
-	Branch          string `long:"branch" description:"Branch to scan"`
-	Report          string `long:"report" description:"path to write json leaks file"`
-	ReportFormat    string `long:"report-format" default:"json" description:"json, csv, sarif"`
-	Redact          bool   `long:"redact" description:"redact secrets from log messages and leaks"`
-	Debug           bool   `long:"debug" description:"log debug messages"`
-	RepoConfig      bool   `long:"repo-config" description:"Load config from target repo. Config file must be \".gitleaks.toml\" or \"gitleaks.toml\""`
-	PrettyPrint     bool   `long:"pretty" description:"Pretty print json if leaks are present"`
+	Verbose       bool   `short:"v" long:"verbose" description:"Show verbose output from scan"`
+	Repo          string `short:"r" long:"repo" description:"Target repository"`
+	Config        string `long:"config" description:"config path"`
+	Disk          bool   `long:"disk" description:"Clones repo(s) to disk"`
+	Version       bool   `long:"version" description:"version number"`
+	Username      string `long:"username" description:"Username for git repo"`
+	Password      string `long:"password" description:"Password for git repo"`
+	AccessToken   string `long:"access-token" description:"Access token for git repo"`
+	FilesAtCommit string `long:"files-at-commit" description:"sha of commit to scan all files at commit"`
+	Threads       int    `long:"threads" description:"Maximum number of threads gitleaks spawns"`
+	SSH           string `long:"ssh-key" description:"path to ssh key used for auth"`
+	Uncommited    bool   `long:"uncommitted" description:"run gitleaks on uncommitted code"`
+	RepoPath      string `long:"repo-path" description:"Path to repo"`
+	OwnerPath     string `long:"owner-path" description:"Path to owner directory (repos discovered)"`
+	Branch        string `long:"branch" description:"Branch to scan"`
+	Report        string `long:"report" description:"path to write json leaks file"`
+	ReportFormat  string `long:"report-format" default:"json" description:"json, csv, sarif"`
+	Redact        bool   `long:"redact" description:"redact secrets from log messages and leaks"`
+	Debug         bool   `long:"debug" description:"log debug messages"`
+	RepoConfig    bool   `long:"repo-config" description:"Load config from target repo. Config file must be \".gitleaks.toml\" or \"gitleaks.toml\""`
+	PrettyPrint   bool   `long:"pretty" description:"Pretty print json if leaks are present"`
 
 	// Commit Options
 	Commit      string `long:"commit" description:"sha of commit to scan or \"latest\" to scan the last commit of the repository"`
@@ -59,9 +59,9 @@ type Options struct {
 	CommitSince string `long:"commit-since" description:"Scan commits more recent than a specific date. Ex: '2006-01-02' or '2006-01-02T15:04:05-0700' format."`
 	CommitUntil string `long:"commit-until" description:"Scan commits older than a specific date. Ex: '2006-01-02' or '2006-01-02T15:04:05-0700' format."`
 
-	Timeout         string `long:"timeout" description:"Time allowed per scan. Ex: 10us, 30s, 1m, 1h10m1s"`
-	Depth           int    `long:"depth" description:"Number of commits to scan"`
-	Deletion        bool   `long:"include-deletion" description:"Scan for patch deletions in addition to patch additions"`
+	Timeout  string `long:"timeout" description:"Time allowed per scan. Ex: 10us, 30s, 1m, 1h10m1s"`
+	Depth    int    `long:"depth" description:"Number of commits to scan"`
+	Deletion bool   `long:"include-deletion" description:"Scan for patch deletions in addition to patch additions"`
 
 	// Hosts
 	Host         string `long:"host" description:"git hosting service like gitlab or github. Supported hosts include: Github, Gitlab"`
@@ -70,6 +70,7 @@ type Options struct {
 	User         string `long:"user" description:"user to scan"`
 	PullRequest  string `long:"pr" description:"pull/merge request url"`
 	ExcludeForks bool   `long:"exclude-forks" description:"scan excludes forks"`
+	Recursive    bool   `long:"traverse-gitlab-groups" description:"traverse Gitlab subgroups"`
 }
 
 // ParseOptions is responsible for parsing options passed in by cli. An Options struct


### PR DESCRIPTION
### Description:
Added a flag to be able to search gitlab subgroups recursively and not only the top group specified in the --org flag.

### Checklist:

* [x ] Does your PR pass tests?
The original ```manager``` test failed in the master branch with ```"manager/manager.go:161: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)"```

After my change the same test fails with the same error. Otherwise all tests works.

* [ ] Have you written new tests for your changes?
No

* [X] Have you lint your code locally prior to submission?
Yes
Automatic formatting changed the structure in the ```options.go```but it is only one line added, i.e. the addition of the recursive flag.

This should solve the Issue #399 