### PR TITLE
Quiet flag

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -21,6 +21,7 @@ import (
 // Options stores values of command line options
 type Options struct {
 	Verbose        bool   `short:"v" long:"verbose" description:"Show verbose output from scan"`
+	Quiet          bool   `short:"q" long:"quiet" description:"Set log level to errors and only output leaks, one per line"`
 	RepoURL        string `short:"r" long:"repo-url" description:"Repository URL"`
 	Path           string `short:"p" long:"path" description:"Path to directory (repo if contains .git) or file"`
 	ConfigPath     string `short:"c" long:"config-path" description:"Path to config"`
@@ -82,6 +83,9 @@ func ParseOptions() (Options, error) {
 
 	if opts.Debug {
 		log.SetLevel(log.DebugLevel)
+	}
+	if opts.Quiet {
+		log.SetLevel(log.ErrorLevel)
 	}
 
 	return opts, nil

--- a/options/options.go
+++ b/options/options.go
@@ -21,7 +21,7 @@ import (
 // Options stores values of command line options
 type Options struct {
 	Verbose        bool   `short:"v" long:"verbose" description:"Show verbose output from scan"`
-	Quiet          bool   `short:"q" long:"quiet" description:"Set log level to errors and only output leaks, one per line"`
+	Quiet          bool   `short:"q" long:"quiet" description:"Sets log level to error and only output leaks, one json object per line"`
 	RepoURL        string `short:"r" long:"repo-url" description:"Repository URL"`
 	Path           string `short:"p" long:"path" description:"Path to directory (repo if contains .git) or file"`
 	ConfigPath     string `short:"c" long:"config-path" description:"Path to config"`

--- a/scan/commit.go
+++ b/scan/commit.go
@@ -95,9 +95,8 @@ func (cs *CommitScanner) Scan() (Report, error) {
 						leak.Rule = rule.Description
 						leak.Tags = strings.Join(rule.Tags, ", ")
 
-						if cs.opts.Verbose {
-							leak.Log(cs.opts.Redact)
-						}
+						leak.Log(cs.opts)
+
 						scannerReport.Leaks = append(scannerReport.Leaks, leak)
 						continue
 					}
@@ -137,9 +136,9 @@ func (cs *CommitScanner) Scan() (Report, error) {
 						leak.LeakURL = leak.URL()
 						leak.Rule = rule.Description
 						leak.Tags = strings.Join(rule.Tags, ", ")
-						if cs.opts.Verbose {
-							leak.Log(cs.opts.Redact)
-						}
+
+						leak.Log(cs.opts)
+
 						scannerReport.Leaks = append(scannerReport.Leaks, leak)
 					}
 				}

--- a/scan/filesatcommit.go
+++ b/scan/filesatcommit.go
@@ -81,9 +81,8 @@ func (fs *FilesAtCommitScanner) Scan() (Report, error) {
 				leak.Rule = rule.Description
 				leak.Tags = strings.Join(rule.Tags, ", ")
 
-				if fs.opts.Verbose {
-					leak.Log(fs.opts.Redact)
-				}
+				leak.Log(fs.opts)
+
 				scannerReport.Leaks = append(scannerReport.Leaks, leak)
 				continue
 			}
@@ -122,9 +121,9 @@ func (fs *FilesAtCommitScanner) Scan() (Report, error) {
 				leak.LeakURL = leak.URL()
 				leak.Rule = rule.Description
 				leak.Tags = strings.Join(rule.Tags, ", ")
-				if fs.opts.Verbose {
-					leak.Log(fs.opts.Redact)
-				}
+
+				leak.Log(fs.opts)
+
 				scannerReport.Leaks = append(scannerReport.Leaks, leak)
 			}
 		}

--- a/scan/leak.go
+++ b/scan/leak.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/zricethezav/gitleaks/v7/options"
+
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
@@ -56,13 +58,22 @@ func (leak Leak) WithCommit(commit *object.Commit) Leak {
 }
 
 // Log logs a leak and redacts if necessary
-func (leak Leak) Log(redact bool) {
-	if redact {
+func (leak Leak) Log(opts options.Options) {
+	if !opts.Quiet && !opts.Verbose {
+		return
+	}
+	if opts.Redact {
 		leak = RedactLeak(leak)
 	}
-	var b []byte
-	b, _ = json.MarshalIndent(leak, "", "	")
-	fmt.Println(string(b))
+	if opts.Quiet {
+		var b []byte
+		b, _ = json.Marshal(leak)
+		fmt.Println(string(b))
+	} else {
+		var b []byte
+		b, _ = json.MarshalIndent(leak, "", "	")
+		fmt.Println(string(b))
+	}
 }
 
 // URL generates a url to the leak if leak.RepoURL is set

--- a/scan/nogit.go
+++ b/scan/nogit.go
@@ -77,9 +77,8 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 					leak.Rule = rule.Description
 					leak.Tags = strings.Join(rule.Tags, ", ")
 
-					if ngs.opts.Verbose {
-						leak.Log(ngs.opts.Redact)
-					}
+					leak.Log(ngs.opts)
+
 					leaks <- leak
 				}
 			}
@@ -120,9 +119,9 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 					leak.LineNumber = lineNumber
 					leak.Rule = rule.Description
 					leak.Tags = strings.Join(rule.Tags, ", ")
-					if ngs.opts.Verbose {
-						leak.Log(ngs.opts.Redact)
-					}
+
+					leak.Log(ngs.opts)
+
 					leaks <- leak
 				}
 			}

--- a/scan/unstaged.go
+++ b/scan/unstaged.go
@@ -86,7 +86,7 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 					leak.Rule = rule.Description
 					leak.Tags = strings.Join(rule.Tags, ", ")
 					if us.opts.Verbose {
-						leak.Log(us.opts.Redact)
+						leak.Log(us.opts)
 					}
 					scannerReport.Leaks = append(scannerReport.Leaks, leak)
 				}
@@ -198,9 +198,9 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 					leak.Repo = us.repoName
 					leak.Rule = rule.Description
 					leak.Tags = strings.Join(rule.Tags, ", ")
-					if us.opts.Verbose {
-						leak.Log(us.opts.Redact)
-					}
+
+					leak.Log(us.opts)
+
 					scannerReport.Leaks = append(scannerReport.Leaks, leak)
 				}
 			}


### PR DESCRIPTION
### Description:
Adds a `-q/--quiet` flag which logs leaks one line at a time instead of the default "pretty" json. This also sets the log level to errors only. Good for processes that was to injest the output of gitleaks without opening a file.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
