### PR TITLE
Print the entropy together with the leak

### DIFF
--- a/scan/commit.go
+++ b/scan/commit.go
@@ -87,7 +87,7 @@ func (cs *CommitScanner) Scan() (Report, error) {
 					}
 
 					if rule.HasFileOrPathLeakOnly(to.Path()) {
-						leak := NewLeak("", "Filename or path offender: "+to.Path(), defaultLineNumber).WithCommit(cs.commit)
+						leak := NewLeak("", "Filename or path offender: "+to.Path(), defaultLineNumber, 0).WithCommit(cs.commit)
 						leak.Repo = cs.repoName
 						leak.File = to.Path()
 						leak.RepoURL = cs.opts.RepoURL
@@ -112,7 +112,7 @@ func (cs *CommitScanner) Scan() (Report, error) {
 							rule.AllowList.CommitAllowed(cs.commit.Hash.String()) {
 							continue
 						}
-						offender := rule.Inspect(line)
+						offender, entropy := rule.Inspect(line)
 						if offender == "" {
 							continue
 						}
@@ -128,7 +128,7 @@ func (cs *CommitScanner) Scan() (Report, error) {
 							continue
 						}
 
-						leak := NewLeak(line, offender, defaultLineNumber).WithCommit(cs.commit)
+						leak := NewLeak(line, offender, defaultLineNumber, entropy).WithCommit(cs.commit)
 						leak.File = to.Path()
 						leak.LineNumber = extractLine(patchContent, leak, lineLookup)
 						leak.RepoURL = cs.opts.RepoURL

--- a/scan/filesatcommit.go
+++ b/scan/filesatcommit.go
@@ -73,7 +73,7 @@ func (fs *FilesAtCommitScanner) Scan() (Report, error) {
 			}
 
 			if rule.HasFileOrPathLeakOnly(f.Name) {
-				leak := NewLeak("", "Filename or path offender: "+f.Name, defaultLineNumber).WithCommit(fs.commit)
+				leak := NewLeak("", "Filename or path offender: "+f.Name, defaultLineNumber, 0).WithCommit(fs.commit)
 				leak.Repo = fs.repoName
 				leak.File = f.Name
 				leak.RepoURL = fs.opts.RepoURL
@@ -96,7 +96,7 @@ func (fs *FilesAtCommitScanner) Scan() (Report, error) {
 					continue
 				}
 
-				offender := rule.Inspect(line)
+				offender, entropy := rule.Inspect(line)
 
 				if offender == "" {
 					continue
@@ -113,7 +113,7 @@ func (fs *FilesAtCommitScanner) Scan() (Report, error) {
 					continue
 				}
 
-				leak := NewLeak(line, offender, defaultLineNumber).WithCommit(fs.commit)
+				leak := NewLeak(line, offender, defaultLineNumber, entropy).WithCommit(fs.commit)
 				leak.File = f.Name
 				leak.LineNumber = i + 1
 				leak.RepoURL = fs.opts.RepoURL

--- a/scan/leak.go
+++ b/scan/leak.go
@@ -3,12 +3,12 @@ package scan
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
-	"github.com/zricethezav/gitleaks/v7/options"
-
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/zricethezav/gitleaks/v7/options"
 )
 
 // Leak is a struct that contains information about some line of code that contains
@@ -28,6 +28,7 @@ type Leak struct {
 	File       string    `json:"file"`
 	Date       time.Time `json:"date"`
 	Tags       string    `json:"tags"`
+	Entropy    float64   `json:"entropy"`
 }
 
 // RedactLeak will replace the offending string with "REDACTED" in both
@@ -39,11 +40,12 @@ func RedactLeak(leak Leak) Leak {
 }
 
 // NewLeak creates a new leak from common data all leaks must have, line, offender, linenumber
-func NewLeak(line string, offender string, lineNumber int) Leak {
+func NewLeak(line string, offender string, lineNumber int, entropy float64) Leak {
 	return Leak{
 		Line:       line,
 		Offender:   offender,
 		LineNumber: lineNumber,
+		Entropy:    math.Round(entropy*1000) / 1000, // 3 points precision is plenty
 	}
 }
 

--- a/scan/nogit.go
+++ b/scan/nogit.go
@@ -72,7 +72,7 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 
 			for _, rule := range ngs.cfg.Rules {
 				if rule.HasFileOrPathLeakOnly(p) {
-					leak := NewLeak("", "Filename or path offender: "+p, defaultLineNumber)
+					leak := NewLeak("", "Filename or path offender: "+p, defaultLineNumber, 0)
 					leak.File = p
 					leak.Rule = rule.Description
 					leak.Tags = strings.Join(rule.Tags, ", ")
@@ -99,7 +99,7 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 						continue
 					}
 
-					offender := rule.Inspect(line)
+					offender, entropy := rule.Inspect(line)
 					if offender == "" {
 						continue
 					}
@@ -114,7 +114,7 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 						continue
 					}
 
-					leak := NewLeak(line, offender, defaultLineNumber)
+					leak := NewLeak(line, offender, defaultLineNumber, entropy)
 					leak.File = p
 					leak.LineNumber = lineNumber
 					leak.Rule = rule.Description

--- a/scan/unstaged.go
+++ b/scan/unstaged.go
@@ -64,7 +64,7 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 			for _, line := range strings.Split(workTreeBuf.String(), "\n") {
 				lineNumber++
 				for _, rule := range us.cfg.Rules {
-					offender := rule.Inspect(line)
+					offender, entropy := rule.Inspect(line)
 					if offender == "" {
 						continue
 					}
@@ -79,7 +79,7 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 					if rule.Path.String() != "" && !rule.HasFilePathLeak(filepath.Base(workTreeFile.Name())) {
 						continue
 					}
-					leak := NewLeak(line, offender, defaultLineNumber).WithCommit(emptyCommit())
+					leak := NewLeak(line, offender, defaultLineNumber, entropy).WithCommit(emptyCommit())
 					leak.File = workTreeFile.Name()
 					leak.LineNumber = lineNumber
 					leak.Repo = us.repoName
@@ -177,7 +177,7 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 
 			for _, line := range strings.Split(diffContents, "\n") {
 				for _, rule := range us.cfg.Rules {
-					offender := rule.Inspect(line)
+					offender, entropy := rule.Inspect(line)
 					if offender == "" {
 						continue
 					}
@@ -192,7 +192,7 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 					if rule.Path.String() != "" && !rule.HasFilePathLeak(filepath.Base(filename)) {
 						continue
 					}
-					leak := NewLeak(line, offender, defaultLineNumber).WithCommit(emptyCommit())
+					leak := NewLeak(line, offender, defaultLineNumber, entropy).WithCommit(emptyCommit())
 					leak.File = filename
 					leak.LineNumber = extractLine(prettyDiff, leak, lineLookup) + 1
 					leak.Repo = us.repoName


### PR DESCRIPTION
### Description:
When configuring entropies to be used in rules, it is very useful to output the calculated entropy alongside the leak.

### Checklist:

* [V ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ V] Have you lint your code locally prior to submission?
