### PR TITLE
Always generate a report if --report is passed

### DIFF
--- a/scan/report.go
+++ b/scan/report.go
@@ -27,7 +27,6 @@ func WriteReport(report Report, opts options.Options, cfg config.Config) error {
 		logrus.Warn("leaks found: ", len(report.Leaks))
 	} else {
 		logrus.Info("No leaks found")
-		return nil
 	}
 
 	if opts.Report == "" {


### PR DESCRIPTION
### Description:
Resolves #505 

### Checklist:

* [x] Does your PR pass tests? (I'm getting a `testing.go:1038: race detected during execution of test` that happens without any changes?)
* [ ] Have you written new tests for your changes? (`options_test.go` is empty?)
* [x] Have you lint your code locally prior to submission?
