### PR TITLE
Slack Webhook Match

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -108,7 +108,7 @@ title = "gitleaks config"
 
 [[rules]]
 	description = "Slack Webhook"
-	regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}'''
+	regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8,12}/[a-zA-Z0-9_]{24}'''
 	tags = ["key", "slack"]
 
 [[rules]]


### PR DESCRIPTION
### Description:
The Slack incoming Webhook URL number increases over time, my suggestion to accept any number from `8-12`.

```
https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}
>>
https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8,12}/[a-zA-Z0-9_]{24}
```

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
