### PR TITLE
Update SARIF output to return empty array if no results were found

### DIFF
--- a/scan/sarif.go
+++ b/scan/sarif.go
@@ -110,7 +110,8 @@ func configToRules(cfg config.Config) []Rules {
 }
 
 func leaksToResults(leaks []Leak) []Results {
-	var results []Results
+	results := make([]Results, 0)
+
 	for _, leak := range leaks {
 		results = append(results, Results{
 			Message: Message{

--- a/scan/unstaged.go
+++ b/scan/unstaged.go
@@ -66,7 +66,7 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 			// Check individual file path ONLY rules
 			for _, rule := range us.cfg.Rules {
 				if rule.HasFileOrPathLeakOnly(fn) {
-					leak := NewLeak("", "Filename or path offender: "+ fn, defaultLineNumber)
+					leak := NewLeak("", "Filename or path offender: "+fn, defaultLineNumber)
 					leak.Repo = us.repoName
 					leak.File = fn
 					leak.RepoURL = us.opts.RepoURL


### PR DESCRIPTION
### Description:
This is a bit pedantic, but according to the [spec ](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317507), the `results` object should be an empty array if the scanner ran successfully.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
