### PR TITLE
SSH auth: Add custom username support

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -184,6 +184,10 @@ func SSHAuth(opts Options) (*ssh.PublicKeys, error) {
 		return nil, fmt.Errorf("user must be specified in the URL")
 	}
 
+	// the part of the RepoURL before the "@" (params[0]) can be something like:
+	// - "ssh://user" if RepoURL is an ssh:// URL
+	// - "user" if RepoURL uses scp-like syntax
+	// we must strip the protocol if it is present so that we only have "user"
 	username := strings.Replace(params[0], "ssh://", "", 1)
 
 	if opts.SSH != "" {

--- a/options/options.go
+++ b/options/options.go
@@ -144,8 +144,8 @@ func (opts Options) CloneOptions() (*git.CloneOptions, error) {
 
 	var auth transport.AuthMethod
 
-	if strings.HasPrefix(opts.RepoURL, "git") {
-		// using git protocol so needs ssh auth
+	if strings.HasPrefix(opts.RepoURL, "ssh://") || (!strings.Contains(opts.RepoURL, "://") && strings.Contains(opts.RepoURL, ":")) {
+		// using ssh:// url or scp-like syntax
 		auth, err = SSHAuth(opts)
 		if err != nil {
 			return nil, err
@@ -176,17 +176,25 @@ func (opts Options) CloneOptions() (*git.CloneOptions, error) {
 // SSHAuth tried to generate ssh public keys based on what was passed via cli. If no
 // path was passed via cli then this will attempt to retrieve keys from the default
 // location for ssh keys, $HOME/.ssh/id_rsa. This function is only called if the
-// repo url using the git:// protocol.
+// repo url using the ssh:// protocol or scp-like syntax.
 func SSHAuth(opts Options) (*ssh.PublicKeys, error) {
+	params := strings.Split(opts.RepoURL, "@")
+
+	if len(params) != 2 {
+		return nil, fmt.Errorf("user must be specified in the URL")
+	}
+
+	username := strings.Replace(params[0], "ssh://", "", 1)
+
 	if opts.SSH != "" {
-		return ssh.NewPublicKeysFromFile("git", opts.SSH, "")
+		return ssh.NewPublicKeysFromFile(username, opts.SSH, "")
 	}
 	c, err := user.Current()
 	if err != nil {
 		return nil, err
 	}
 	defaultPath := fmt.Sprintf("%s/.ssh/id_rsa", c.HomeDir)
-	return ssh.NewPublicKeysFromFile("git", defaultPath, "")
+	return ssh.NewPublicKeysFromFile(username, defaultPath, "")
 }
 
 // OpenLocal checks what options are set, if no remote targets are set


### PR DESCRIPTION
### Description:
This PR adds support for custom usernames when cloning repositories using SSH authentication.
Previously, the user `git` was hard-coded.

This PR also adds compatibility for using `ssh://` repo URLs without using ssh-agent.
A PR such as #495 will have to be merged to restore ssh-agent compatibility.
I will remove this part if such a breaking change is not desirable.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
