### PR TITLE
Removes unnecessary CRLF in logging

### DIFF
--- a/scan/parent.go
+++ b/scan/parent.go
@@ -30,7 +30,7 @@ func NewParentScanner(opts options.Options, cfg config.Config) *ParentScanner {
 // Scan kicks off a ParentScanner scan. This uses the directory from --path to discovery repos
 func (ds *ParentScanner) Scan() (Report, error) {
 	var scannerReport Report
-	log.Debugf("scanning repos in %s\n", ds.opts.Path)
+	log.Debugf("scanning repos in %s", ds.opts.Path)
 
 	files, err := ioutil.ReadDir(ds.opts.Path)
 	if err != nil {

--- a/scan/utils.go
+++ b/scan/utils.go
@@ -54,7 +54,7 @@ func getRepoName(opts options.Options) string {
 func getRepo(opts options.Options) (*git.Repository, error) {
 	if opts.OpenLocal() {
 		if opts.Path != "" {
-			log.Infof("opening %s\n", opts.Path)
+			log.Infof("opening %s", opts.Path)
 		} else {
 			log.Info("opening .")
 		}
@@ -66,7 +66,7 @@ func getRepo(opts options.Options) (*git.Repository, error) {
 		if err != nil {
 			return nil, err
 		}
-		log.Debugf("opening %s as a repo\n", dir)
+		log.Debugf("opening %s as a repo", dir)
 		return git.PlainOpen(dir)
 	}
 	return cloneRepo(opts)


### PR DESCRIPTION
Removed 3 '\n' occurences in logging

### Description:

Some '\n' were included in log messages.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
