### PR TITLE
Add pre-commit support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: gitleaks
+  name: Detect hardcoded secrets
+  description: Detect hardcoded secrets using Gitleaks
+  entry: gitleaks
+  language: golang

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Gitleaks is a SAST tool for detecting hardcoded secrets like passwords, api keys
 
 
 ### Installation
-Gitleaks can be installed using Homebrew, Docker, or Go. Gitleaks is also available in binary form for many popular platforms and OS types on the [releases page](https://github.com/zricethezav/gitleaks/releases).
+Gitleaks can be installed using Homebrew, Docker, or Go. Gitleaks is also available in binary form for many popular platforms and OS types on the [releases page](https://github.com/zricethezav/gitleaks/releases). In addition, Gitleaks can be implemented as a pre-commit hook directly in your repo.
 
 ##### MacOS
 
@@ -41,6 +41,18 @@ docker pull zricethezav/gitleaks
 ##### Go
 ```bash
 GO111MODULE=on go get github.com/zricethezav/gitleaks/v7
+```
+##### As a pre-commit hook
+
+See [pre-commit](https://github.com/pre-commit/pre-commit) for instructions.
+
+Sample `.pre-commit-config.yaml`
+
+```yaml
+-   repo: https://github.com/zricethezav/gitleaks
+    rev: v7.4.0
+    hooks:
+    -   id: gitleaks
 ```
 
 ### Usage and Options


### PR DESCRIPTION
### Description:
Add [pre-commit](https://pre-commit.com/index.html#new-hooks) OOB support.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

### Tests:

1. Locally with `pre-commit try-repo ../gitleaks gitleaks --verbose` 
2. By configuring my forked repo as the source:
```
- repo: https://github.com/pab1it0/gitleaks
  rev: d8ebc3c85dd4c95ed254168cbcd68d61f48df0ce
  hooks:
  - id: gitleaks
    args:
    - --verbose
```

Both were tested by committing [test_data dir](https://github.com/zricethezav/gitleaks/tree/master/test_data) to a separate repo where `.pre-commit-config.yaml ` was configured. Following hook execution, 218 leaks were found. Log is attached as `result.log`.
[result.log](https://github.com/zricethezav/gitleaks/files/6357617/result.log)

Once approved, a corresponding PR will be created to add this repo to: https://github.com/pre-commit/pre-commit.com/blob/master/all-repos.yaml and appear in the [supported pre-commit hooks](https://pre-commit.com/hooks.html)