### PR TITLE
Removed unnecessary backslashes in default config

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -80,7 +80,7 @@ title = "gitleaks config"
 
 [[rules]]
     description = "Google API key"
-    regex = '''AIza[0-9A-Za-z\\-_]{35}'''
+    regex = '''AIza[0-9A-Za-z\-_]{35}'''
     tags = ["key", "Google"]
 
 [[rules]]
@@ -135,7 +135,7 @@ title = "gitleaks config"
 
 [[rules]]
     description = "Square OAuth secret"
-    regex = '''sq0csp-[0-9A-Za-z\\-_]{43}'''
+    regex = '''sq0csp-[0-9A-Za-z\-_]{43}'''
     tags = ["key", "square"]
 
 [[rules]]


### PR DESCRIPTION
### Description:
Removed unnecessary backslashes in the default config that prevented Google API keys and Square OAuth secrets from being detected.

### Checklist:

* [V] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [V] Have you lint your code locally prior to submission?
