### PR TITLE
regex whith ckan key pattern included in withing default keys

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -7,6 +7,11 @@ const DefaultConfig = `
 title = "gitleaks config"
 
 [[rules]]
+    description = "CKAN Key"
+    regex = '''\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'''
+    tags = ["key", "AWS"]
+
+[[rules]]
     description = "AWS Access Key"
     regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]


### PR DESCRIPTION
### Description:
[Ckan](https://ckan.org/) is the world’s leading open-source data management system and it's used for open data portals all over the world, like [Canada](https://open.canada.ca/en/open-data). I've been working on some python packages for my [public office's portal](https://dados.mg.gov.br/) and find it interesting to scan the project to see "lose keys" and thanks to gitleaks I prevent this kind of error before pushing the code to GitHub. The only problem was to use --config-path to put this specific regex pattern. Maybe others could have the same problem regardless Ckan community size.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
