### PR TITLE
fix --no-git rule, not properly ignoring .git folder

### DIFF
--- a/config/allowlist.go
+++ b/config/allowlist.go
@@ -6,7 +6,7 @@ import (
 
 // used for ignoring .git directories when the --no-git flag is set
 // related issue: https://github.com/zricethezav/gitleaks/issues/486
-const dotGit = `/\.git/`
+const dotGit = `^\.git/`
 
 // AllowList is struct containing items that if encountered will allowlist
 // a commit/line of code that would be considered a leak.


### PR DESCRIPTION
### Description:
The current release doesn't ignore the `.git` folder as expected
Likely due to the changes made in this PR: #507

The changed proposed in this PR works with the scenario exposed on #507, and also ignores `.git` folder properly

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
