### PR TITLE
FIX: Upgraded docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM golang:1.15.5 AS build
+ARG ALPINE_IMAGE_VERSION=3.14.1
+ARG GOLANG_IMAGE_VERSION=1.17.0
+FROM golang:$GOLANG_IMAGE_VERSION AS build
 WORKDIR /go/src/github.com/zricethezav/gitleaks
 ARG ldflags
 COPY . .
 RUN GO111MODULE=on CGO_ENABLED=0 go build -o bin/gitleaks -ldflags "-X="${ldflags} *.go 
 
-FROM alpine:3.11
-RUN apk add --no-cache bash git openssh
+FROM alpine:$ALPINE_IMAGE_VERSION
+RUN adduser -D gitleaks && \
+    apk add --no-cache bash git openssh-client
 COPY --from=build /go/src/github.com/zricethezav/gitleaks/bin/* /usr/bin/
+USER gitleaks
 ENTRYPOINT ["gitleaks"]
 
 # How to use me :
@@ -15,3 +19,6 @@ ENTRYPOINT ["gitleaks"]
 # docker run --rm --name=gitleaks gitleaks --repo-url=https://github.com/zricethezav/gitleaks
 
 # This will check for secrets in https://github.com/zricethezav/gitleaks
+
+# To scan the current local directory, no git
+# docker run --rm -v $(pwd):/tmp --name=gitleaks zricethezav/gitleaks --path=/tmp --no-git

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ PKG=github.com/zricethezav/gitleaks
 LDFLAGS=-ldflags "-X=github.com/zricethezav/gitleaks/v7/version.Version=$(VERSION)"
 _LDFLAGS="github.com/zricethezav/gitleaks/v7/version.Version=$(VERSION)"
 COVER=--cover --coverprofile=cover.out
+IMAGE_PATH = "zricethezav/gitleaks"
+ALPINE_VERSION = 3.14.1
+GOLANG_VERSION = 1.17.0
+DOCKER_BUILD_ARGS=--build-arg ALPINE_IMAGE_VERSION=$(ALPINE_VERSION) --build-arg GOLANG_IMAGE_VERSION=$(GOLANG_VERSION) --build-arg ldflags=$(_LDFLAGS)
 
 test-cover:
 	go test ./... --race $(COVER) $(PKG) -v
@@ -33,8 +37,7 @@ release-builds:
 	rm -rf build
 	mkdir build
 	env GOOS="windows" GOARCH="amd64" go build -o "build/gitleaks-windows-amd64.exe" $(LDFLAGS)
-	env GOOS="windows" GOARCH="386" go build -o "build/gitleaks-windows-386.exe" $(LDFLAGS)
-	env GOOS="linux" GOARCH="amd64" go build -o "build/gitleaks-linux-amd64" $(LDFLAGS)
+	env GOOS="windows" GOARCH="386" go$(DOCKER_BUILD_ARGS) uild -o "build/gitleaks-linux-amd64" $(LDFLAGS)
 	env GOOS="linux" GOARCH="arm" go build -o "build/gitleaks-linux-arm" $(LDFLAGS)
 	env GOOS="linux" GOARCH="mips" go build -o "build/gitleaks-linux-mips" $(LDFLAGS)
 	env GOOS="linux" GOARCH="mips" go build -o "build/gitleaks-linux-mips" $(LDFLAGS)
@@ -42,9 +45,9 @@ release-builds:
 
 deploy:
 	@echo "$(DOCKER_PASSWORD)" | docker login -u "$(DOCKER_USERNAME)" --password-stdin
-	docker build --build-arg ldflags=$(_LDFLAGS) -f Dockerfile -t zricethezav/gitleaks:latest -t zricethezav/gitleaks:$(VERSION) .
-	echo "Pushing zricethezav/gitleaks:$(VERSION) and zricethezav/gitleaks:latest"
-	docker push zricethezav/gitleaks
+	docker build $(DOCKER_BUILD_ARGS) -f Dockerfile -t $(IMAGE_PATH):latest -t $(IMAGE_PATH):$(VERSION) .
+	echo "Pushing $(IMAGE_PATH):$(VERSION) and $(IMAGE_PATH):latest"
+	docker push $(IMAGE_PATH)
 
 dockerbuild:
-	docker build --build-arg ldflags=$(_LDFLAGS) -f Dockerfile -t zricethezav/gitleaks:latest -t zricethezav/gitleaks:$(VERSION) .
+	docker build $(DOCKER_BUILD_ARGS) -f Dockerfile -t $(IMAGE_PATH):latest -t $(IMAGE_PATH):$(VERSION) .


### PR DESCRIPTION
There were security issues reported in several components in the
Dockerfile. This PR fixes them. It should not introduce any
breaking changes, but this container does now run as a 'gitleaks'
user.

Issues reported:
* 3 Vulnerabilities in Openssh v8.1_p1-r0
* 1 Vulnerability in busybox v 1.31.1-r9
* 1 Vulnerability in apk-tools v2.10.5-r0
* 1 CIS best practices issue - Container did not run as non-root

Additional fixes/changes
* Refactored Dockerfile to allow easier upgrades in the future
through ARGuments.
* Refactored makefile to support additional arguments
* Refactored makefile with an IMAGE_PATH to make future container
tests easier
* Downgraded to openssh-client instead of openssh*. Having the
openssh server in the container is a bad practice.
* Did *not* version pin the APKs as that is against Alpine guidance

Fixes #562

NOTE: I was *not* able to scan using the proprietary twistlock tool. 

### Description:
Explain the purpose of the PR.

### Checklist:

* [X] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
