### PR TITLE
fix(git-symlink-commits): fix handling symbolic links in a git repository

### DIFF
--- a/scan/unstaged.go
+++ b/scan/unstaged.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -156,6 +157,9 @@ func (us *UnstagedScanner) Scan() (Report, error) {
 				// file in staging has been deleted, aka it is not on the filesystem
 				// so the contents of the file are ""
 				currFileContents = ""
+				//check if file is symlink
+			} else if fc, err := os.Readlink(fn); err == nil {
+				currFileContents = fc
 			} else {
 				workTreeBuf := bytes.NewBuffer(nil)
 				workTreeFile, err := wt.Filesystem.Open(fn)


### PR DESCRIPTION
### Description:
gitleaks failed to scan commits contains symlinks.

How to reproduce:

```shell
mkdir /tmp/foo
cd $_
git init -q
mkdir dir
ln -s dir link
docker run --rm -v $PWD:/src --workdir /src zricethezav/gitleaks --verbose
```
Note that I confirmed that it's NOT a docker issue and the binary behave the same way.

Offered solution:
add check determines if file path is symlink, if so instead of reading it use the link path as content.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
