### PR TITLE
Fix default twitter rules

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -33,12 +33,12 @@ title = "gitleaks config"
 
 [[rules]]
     description = "Twitter Secret Key"
-    regex = '''(?i)twitter(.{0,20})?[0-9a-z]{35,44}'''
+    regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{35,44}['\"]'''
     tags = ["key", "Twitter"]
 
 [[rules]]
     description = "Twitter Client ID"
-    regex = '''(?i)twitter(.{0,20})?[0-9a-z]{18,25}'''
+    regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{18,25}['\"]'''
     tags = ["client", "Twitter"]
 
 [[rules]]


### PR DESCRIPTION
### Description:
Regexps for default Twitter rules ("Twitter Secret Key" and "Twitter Client
ID") have a small flaw that make the default configuration vulnerable to
some false-positives.

I believe these rules should detect the cases like (SOME_CLIENT_ID should
be longer):
```
"twitter_client_id": "SOME_CLIENT_ID"
```

However, currently the twitter rules also detect the false positives for the
cases like:
```
someObj := twitter.NewObjectWithALongName()
config.Twitter.DomainAccessToken
```

I'm trying to address this issue the similar way it's done for facebook client
ids and AWS secret keys, where the secret is expected to be quoted.

Also, I make the rules consistent with the rules defined in [gitleaks-action](https://github.com/zricethezav/gitleaks-action/blob/master/.gitleaks.toml)

Resolves https://github.com/zricethezav/gitleaks/issues/604
Resolves https://github.com/zricethezav/gitleaks/issues/454

### Checklist:

* [X] Does your PR pass tests?
* [ ] Have you written new tests for your changes? (**No, should I?**)
* [X] Have you lint your code locally prior to submission?
