### PR TITLE
Fix premature exit for nogit scans, limit goroutines

### DIFF
--- a/scan/nogit.go
+++ b/scan/nogit.go
@@ -51,7 +51,6 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 	g, _ := errgroup.WithContext(context.Background())
 
 	paths := make(chan string)
-	filesScanned := 0
 
 	g.Go(func() error {
 		defer close(paths)
@@ -69,7 +68,6 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 
 	for path := range paths {
 		p := path
-		filesScanned++
 		ngs.throttle.Limit()
 		g.Go(func() error {
 			defer ngs.throttle.Release()
@@ -153,8 +151,6 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 	if err := g.Wait(); err != nil {
 		log.Error(err)
 	}
-
-	log.Info(filesScanned)
 
 	return scannerReport, nil
 }

--- a/scan/nogit.go
+++ b/scan/nogit.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 
@@ -17,15 +18,19 @@ import (
 
 // NoGitScanner is a scanner that absolutely despises git
 type NoGitScanner struct {
-	opts options.Options
-	cfg  config.Config
+	opts     options.Options
+	cfg      config.Config
+	throttle *Throttle
+	mtx      *sync.Mutex
 }
 
 // NewNoGitScanner creates and returns a nogit scanner. This is used for scanning files and directories
 func NewNoGitScanner(opts options.Options, cfg config.Config) *NoGitScanner {
 	ngs := &NoGitScanner{
-		opts: opts,
-		cfg:  cfg,
+		opts:     opts,
+		cfg:      cfg,
+		throttle: NewThrottle(opts),
+		mtx:      &sync.Mutex{},
 	}
 
 	// no-git scans should ignore .git folders by default
@@ -44,7 +49,9 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 	var scannerReport Report
 
 	g, _ := errgroup.WithContext(context.Background())
-	paths := make(chan string, 100)
+
+	paths := make(chan string)
+	filesScanned := 0
 
 	g.Go(func() error {
 		defer close(paths)
@@ -60,11 +67,12 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 			})
 	})
 
-	leaks := make(chan Leak, 100)
-
 	for path := range paths {
 		p := path
+		filesScanned++
+		ngs.throttle.Limit()
 		g.Go(func() error {
+			defer ngs.throttle.Release()
 			if ngs.cfg.Allowlist.FileAllowed(filepath.Base(p)) ||
 				ngs.cfg.Allowlist.PathAllowed(p) {
 				return nil
@@ -84,7 +92,9 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 
 					leak.Log(ngs.opts)
 
-					leaks <- leak
+					ngs.mtx.Lock()
+					scannerReport.Leaks = append(scannerReport.Leaks, leak)
+					ngs.mtx.Unlock()
 				}
 			}
 
@@ -129,26 +139,22 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 					leak.LineNumber = lineNumber
 					leak.Rule = rule.Description
 					leak.Tags = strings.Join(rule.Tags, ", ")
-
 					leak.Log(ngs.opts)
 
-					leaks <- leak
+					ngs.mtx.Lock()
+					scannerReport.Leaks = append(scannerReport.Leaks, leak)
+					ngs.mtx.Unlock()
 				}
 			}
 			return f.Close()
 		})
 	}
 
-	go func() {
-		if err := g.Wait(); err != nil {
-			log.Error(err)
-		}
-		close(leaks)
-	}()
-
-	for leak := range leaks {
-		scannerReport.Leaks = append(scannerReport.Leaks, leak)
+	if err := g.Wait(); err != nil {
+		log.Error(err)
 	}
 
-	return scannerReport, g.Wait()
+	log.Info(filesScanned)
+
+	return scannerReport, nil
 }


### PR DESCRIPTION
### Description:
This PR takes care of two things that are related.

1.  `--nogit` scans previously did not limit the number of goroutines being spun up so the `--threads` option was non functioning 😬. Because of this, the default behavior would essentially max out all available cpu resources assuming the target was large enough. Sorry bout that folks.

2. `--nogit` would prematurely exit if a leak was found early in a scan before the leak channel receiver started. So instead of sending leaks via channel I'm just surrounding the leaks slice with a mutex and calling it a day. It's a boring and safe solution.

### Checklist:

* [x] Does your PR pass tests?
* [-] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
