### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on
@@ -25,6 +27,8 @@ jobs:
       run: go build -v ./...
 
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on


### PR DESCRIPTION
### Description:
This PR adds specific permissions to the existing workflows under .github/workflows

### Background

GitHub provides a [feature](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) to set permissions for the GITHUB_TOKEN. I have implemented a [GitHub App](https://github.com/apps/step-security) to automatically calculate the right permissions for a given workflow.  

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows.  

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. Please try it out on other repos and share your feedback. Thanks!

### Checklist:

* [X] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
