### PR TITLE
Update gitleaks.toml

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -167,6 +167,16 @@ title = "gitleaks config"
     description = "PyPI upload token"
     regex = '''pypi-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
     tags = ["key", "pypi"]
+    
+[[rules]]
+    description = "Octopus deploy"
+    regex = '''api-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
+    tags = ["key", "API"]
+    
+[[rules]]
+    description = "Sonarqube and other scanner tools"
+    regex = '''api-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
+    tags = ["key", "api"]
 
 [allowlist]
     description = "Allowlisted files"


### PR DESCRIPTION
We tested this repo in gitlab and it fails to see hardcoded keys with name API-XXXX and api-XXXX.These keys words need to be detected so adding this to fix the issue

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
