### PR TITLE
Pull request to detect API keys,bearer token and JWT token hardcoded in gitlab/github ci file

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -167,6 +167,16 @@ title = "gitleaks config"
     description = "PyPI upload token"
     regex = '''pypi-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
     tags = ["key", "pypi"]
+    
+[[rules]]
+    description = "Octopus deploy"
+    regex = '''api-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
+    tags = ["key", "API"]
+    
+[[rules]]
+    description = "Sonarqube and other scanner tools"
+    regex = '''api-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
+    tags = ["key", "api"]
 
 [allowlist]
     description = "Allowlisted files"

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -170,7 +170,7 @@ title = "gitleaks config"
     
 [[rules]]
     description = "Octopus deploy"
-    regex = '''api-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
+    regex = '''API-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
     tags = ["key", "API"]
     
 [[rules]]
@@ -178,6 +178,16 @@ title = "gitleaks config"
     regex = '''api-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
     tags = ["key", "api"]
 
+[[rules]]
+    description = "Authoraization Bearer token"
+    regex = '''Bearer\s[\d|a-f]{8}-([\d|a-f]{4}-){3}[\d|a-f]{12}'''
+    tags = ["key", "Bearer"]
+    
+[[rules]]
+    description = "JWT token found in gitlab ci file"
+    regex = '''^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$'''
+    tags = ["key", "JWT"]
+    
 [allowlist]
     description = "Allowlisted files"
     files = ['''^\.?gitleaks.toml$''',


### PR DESCRIPTION
### Description:
Explain the purpose of the PR.

During our tests for gitleaks using this temnplate in gitlab we could find API keys in format API and api were not detected,also bearer token and JWT token hardcoded were also not detected.

Created pull request to add these to file so that it detected these and avoids security issues

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
