### PR TITLE
fix: fix the multiple executions to one when executing gitleaks from the pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,4 @@
   description: Detect hardcoded secrets using Gitleaks
   entry: gitleaks
   language: golang
+  pass_filenames: false


### PR DESCRIPTION
### Description:
PR is to fix [Issue #595.](https://github.com/zricethezav/gitleaks/issues/595)

If the pre-commit hook for gitleaks is used, gitleaks is executed multiple times.  For example,
`
$ pre-commit run -a
Detect hardcoded secrets.................................................Failed
- hook id: gitleaks
- exit code: 1

INFO[0000] opening .
INFO[0000] scan time: 428 milliseconds 438 microseconds
WARN[0000] leaks found: 1
INFO[0000] opening .
INFO[0000] scan time: 447 milliseconds 648 microseconds
WARN[0000] leaks found: 1
`

The output should be
`
$ pre-commit run -a
Detect hardcoded secrets.................................................Failed
- hook id: gitleaks
- exit code: 1

INFO[0000] opening .
INFO[0000] scan time: 428 milliseconds 438 microseconds
WARN[0000] leaks found: 1
`

Updated the .pre-commit-config.yaml to prevent the multiple executions.

### Checklist:

* [ ] Does your PR pass tests?   pre-commit framework tests do not exist.
* [ ] Have you written new tests for your changes? pre-commit framework tests do not exist.
* [ ] Have you lint your code locally prior to submission?  Not applicable.
