### PR TITLE
feat: add svg extension to default allow list

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -171,5 +171,5 @@ title = "gitleaks config"
 [allowlist]
     description = "Allowlisted files"
     files = ['''^\.?gitleaks.toml$''',
-    '''(.*?)(png|jpg|gif|doc|docx|pdf|bin|xls|pyc|zip)$''',
+    '''(.*?)(png|jpg|gif|svg|doc|docx|pdf|bin|xls|pyc|zip)$''',
     '''(go.mod|go.sum)$''']


### PR DESCRIPTION
### Description:
In our internal continuous integration system we are having false positives on svg files that have base64 embedded raster images.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
