### PR TITLE
Bump alpine to v3.14.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ldflags
 COPY . .
 RUN GO111MODULE=on CGO_ENABLED=0 go build -o bin/gitleaks -ldflags "-X="${ldflags} *.go 
 
-FROM alpine:3.14.1
+FROM alpine:3.14.2
 RUN adduser -D gitleaks && \
     apk add --no-cache bash git openssh-client
 COPY --from=build /go/src/github.com/zricethezav/gitleaks/bin/* /usr/bin/


### PR DESCRIPTION
### Description:
This alpine release includes fixes for openssl CVE-2021-3711 (NVD 9.8 CRITICAL) and CVE-2021-3712 (NVD 7.4 HIGH).

### Checklist:

* [x] Successfully build docker image locally and ran against testdata/repos?
* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
