### PR TITLE
fix: csv report in excel

### DIFF
--- a/scan/report.go
+++ b/scan/report.go
@@ -4,8 +4,8 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"os"
-	"strings"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
### Description:
The purpose of this PR is to fix the bug in issue #359. Opening a report in csv file format with new line characters in commits containing leaks throws an error, for Excel. 

To solve that I use a regex expression that replaces `\r\n` and `\n` for white-spaces. That way we have the full commit message in the report, and we maintain consistency through different programs.


### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
