### PR TITLE
feat: (POC) handle multiple paths

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
   entry: gitleaks
+  args: [--all-files]
   language: golang
-  pass_filenames: false

--- a/scan/nogit.go
+++ b/scan/nogit.go
@@ -50,16 +50,29 @@ func (ngs *NoGitScanner) Scan() (Report, error) {
 	paths := make(chan string)
 	g.Go(func() error {
 		defer close(paths)
-		return filepath.Walk(ngs.opts.Path,
-			func(path string, fInfo os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-				if fInfo.Mode().IsRegular() {
-					paths <- path
-				}
-				return nil
-			})
+		if len(ngs.opts.ListOfFiles) == 0 {
+			return filepath.Walk(ngs.opts.Path,
+				func(path string, fInfo os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+					if fInfo.Mode().IsRegular() {
+						paths <- path
+					}
+					return nil
+				})
+		}
+
+		for _, path := range ngs.opts.ListOfFiles {
+			filepath.Walk(path,
+				func(path string, fInfo os.FileInfo, err error) error {
+					if fInfo.Mode().IsRegular() {
+						paths <- path
+					}
+					return nil
+				})
+		}
+		return nil
 	})
 
 	for path := range paths {

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -148,6 +148,9 @@ func scanType(opts options.Options) (ScannerType, error) {
 		}
 		return typeNoGitScanner, nil
 	}
+	if len(opts.ListOfFiles) != 0 {
+		return typeNoGitScanner, nil
+	}
 	if opts.CheckUncommitted() {
 		return typeUnstagedScanner, nil
 	}


### PR DESCRIPTION
### Description:
This PR is a Proof Of Concept changing the behaviour of gitleaks cli to match `pre-commit run` and `pre-commit run -a`.
Close #657.

The PoC consists on adding a new option to the gitleaks cli, named --all-files. If the user uses this flag, gitleaks will create disregard any other flag and will create a "no git scanner". The list of files to scan will be created from the `--all-files` argument and all the arguments at the end. 

Example:
We execute `gitleaks --all-files file1 file2 file3 ... fileN`.
- Gitleaks will disregard any argument when using --all-files
- A no git scanner will be created to scan each file individually
- Gitleaks will receive file1 and [file2 file3 ... fileN]. We will create the list of files by concatenating both things [file1 ... fileN]

Things to consider about this PoC that should be improved:
- The use of the reflect library to compare structs
- Handle what happens if one file of the list does not exist, cannot be open, ...

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
