### PR TITLE
fix possible typo in README.md `leaves` had been written instead of `leaks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ So you can use the following to effectively create the proper Perl regex:
 
 
 ### Exit Codes
-You can always set the exit code when leaves are encountered with the `--leaks-exit-code` flag. Default exit codes below:
+You can always set the exit code when leaks are encountered with the `--leaks-exit-code` flag. Default exit codes below:
 ```
 0 - no leaks present
 1 - leaks or error encountered


### PR DESCRIPTION
### Description:
This PR is to fix possible typo in README.md. `leaves` had been written instead of `leaks` 

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
