### PR TITLE
Add curl and JQ as default packages in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 go build -o bin/gitleaks -ldflags "-X="${ldflag
 
 FROM alpine:3.14.1
 RUN adduser -D gitleaks && \
-    apk add --no-cache bash git openssh-client
+    apk add --no-cache bash git openssh-client curl jq
 COPY --from=build /go/src/github.com/zricethezav/gitleaks/bin/* /usr/bin/
 USER gitleaks
 ENTRYPOINT ["gitleaks"]


### PR DESCRIPTION
### Description:

That PR adds `curl` and `jq` as default packages.

#615 introduce the `gitleaks` user as default user in docker image.
In my usage, and I presume, usage of many user, Gitleaks is integrated on CI pipeline and with the new default user, we are not able to customise the image without forking/rebuild, which is not best to stay up to date.

Both tools are particularly useful in context of CI to be able to send report to an API and/or filter results.

### Checklist:

* [x] Does your PR pass tests? `make dockerbuild` command was run with success.
* [-] Have you written new tests for your changes?
* [-] Have you lint your code locally prior to submission?


Note : I wasn't sure if I had to target master or v8 branch. v8 seems to be more up to date so I choose it.
Let me know if I need to change.
