### PR TITLE
lil hack to avoid scans 'finishing' when git errors are present

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gitleaks/go-gitdiff/gitdiff"
 	"github.com/rs/zerolog/log"
@@ -39,6 +40,7 @@ func GitLog(source string, logOpts string) (<-chan *gitdiff.File, error) {
 	}
 
 	go listenForStdErr(stderr)
+	time.Sleep(50 * time.Millisecond) // HACK: to avoid https://github.com/zricethezav/gitleaks/issues/722
 
 	return gitdiff.Parse(stdout)
 }
@@ -66,6 +68,7 @@ func GitDiff(source string, staged bool) (<-chan *gitdiff.File, error) {
 	}
 
 	go listenForStdErr(stderr)
+	time.Sleep(50 * time.Millisecond) // HACK: to avoid https://github.com/zricethezav/gitleaks/issues/722
 
 	return gitdiff.Parse(stdout)
 }


### PR DESCRIPTION
### Description:
Added a sleeper for 50 ms to give the listenforstderr function enough time to catch most immediate errors coming from stderr.

Fixes https://github.com/zricethezav/gitleaks/issues/722

### Checklist:

* [x] Does your PR pass tests?
* [-] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
