### PR TITLE
do not fail on git rename warning

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -13,7 +13,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// GitLog returns a channel of gitdiff.File objects from the git log -p command for the given source.
+// GitLog returns a channel of gitdiff.File objects from the
+// git log -p command for the given source.
 func GitLog(source string, logOpts string) (<-chan *gitdiff.File, error) {
 	sourceClean := filepath.Clean(source)
 	var cmd *exec.Cmd
@@ -22,7 +23,8 @@ func GitLog(source string, logOpts string) (<-chan *gitdiff.File, error) {
 		args = append(args, strings.Split(logOpts, " ")...)
 		cmd = exec.Command("git", args...)
 	} else {
-		cmd = exec.Command("git", "-C", sourceClean, "log", "-p", "-U0", "--full-history", "--all")
+		cmd = exec.Command("git", "-C", sourceClean, "log", "-p", "-U0",
+			"--full-history", "--all")
 	}
 
 	log.Debug().Msgf("executing: %s", cmd.String())
@@ -40,18 +42,21 @@ func GitLog(source string, logOpts string) (<-chan *gitdiff.File, error) {
 	}
 
 	go listenForStdErr(stderr)
-	time.Sleep(50 * time.Millisecond) // HACK: to avoid https://github.com/zricethezav/gitleaks/issues/722
+	// HACK: to avoid https://github.com/zricethezav/gitleaks/issues/722
+	time.Sleep(50 * time.Millisecond)
 
 	return gitdiff.Parse(stdout)
 }
 
-// GitDiff returns a channel of gitdiff.File objects from the git diff command for the given source.
+// GitDiff returns a channel of gitdiff.File objects from
+// the git diff command for the given source.
 func GitDiff(source string, staged bool) (<-chan *gitdiff.File, error) {
 	sourceClean := filepath.Clean(source)
 	var cmd *exec.Cmd
 	cmd = exec.Command("git", "-C", sourceClean, "diff", "-U0", ".")
 	if staged {
-		cmd = exec.Command("git", "-C", sourceClean, "diff", "-U0", "--staged", ".")
+		cmd = exec.Command("git", "-C", sourceClean, "diff", "-U0",
+			"--staged", ".")
 	}
 	log.Debug().Msgf("executing: %s", cmd.String())
 
@@ -68,7 +73,8 @@ func GitDiff(source string, staged bool) (<-chan *gitdiff.File, error) {
 	}
 
 	go listenForStdErr(stderr)
-	time.Sleep(50 * time.Millisecond) // HACK: to avoid https://github.com/zricethezav/gitleaks/issues/722
+	// HACK: to avoid https://github.com/zricethezav/gitleaks/issues/722
+	time.Sleep(50 * time.Millisecond)
 
 	return gitdiff.Parse(stdout)
 }
@@ -79,8 +85,26 @@ func listenForStdErr(stderr io.ReadCloser) {
 	scanner := bufio.NewScanner(stderr)
 	errEncountered := false
 	for scanner.Scan() {
-		log.Error().Msg(scanner.Text())
-		errEncountered = true
+		// if git throws the following error:
+		//
+		//  exhaustive rename detection was skipped due to too many files.
+		//  you may want to set your diff.renameLimit variable to at least
+		//  (some large number) and retry the command.
+		//
+		// we skip exiting the program as git log -p/git diff will continue
+		// to send data to stdout and finish executing. This next bit of
+		// code prevents gitleaks from stopping mid scan if this error is
+		// encountered
+		if strings.Contains(scanner.Text(),
+			"exhaustive rename detection was skipped") ||
+			strings.Contains(scanner.Text(),
+				"you may want to set your diff.renameLimit") {
+
+			log.Warn().Msg(scanner.Text())
+		} else {
+			log.Error().Msg(scanner.Text())
+			errEncountered = true
+		}
 	}
 	if errEncountered {
 		os.Exit(1)


### PR DESCRIPTION
### Description:
I discovered a bug when scanning a large repo which resulting in the following error message:
```
10:05AM ERR warning: exhaustive rename detection was skipped due to too many files.
10:05AM ERR warning: you may want to set your diff.renameLimit variable to at least 2502 and retry the command.
```

this PR adds an exception to rename errs so that gitleaks will continue finishing the scan even if one commit results in a rename warning.

### Checklist:

* [x] Does your PR pass tests?
* [-] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
