### PR TITLE
fix regexp for aws_key and slack_webhook

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -37,7 +37,7 @@ regex = '''glpat-[0-9a-zA-Z\-]{20}'''
 [[rules]]
 id = "aws-access-token"
 description = "AWS"
-regex = '''AKIA[0-9A-Z]{16}'''
+regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
 
 # Cryptographic keys
 [[rules]]
@@ -140,7 +140,7 @@ secretGroup = 3
 [[rules]]
 id = "slack-web-hook"
 description = "Slack Webhook"
-regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}'''
+regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8,12}/[a-zA-Z0-9_]{24}'''
 
 [[rules]]
 id = "twilio-api-key"


### PR DESCRIPTION
### Description:
fixing regex patterns that were present in `v7.6.1` for AWS and Slack and worked nicely.
Currently deployed `v8.2.1` does not identify the compromised Slack Webhooks and AWS Keys.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
