### PR TITLE
ignore k8s apiVersion in generic-api-key pattern

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -535,7 +535,7 @@ secretGroup = 3
 [[rules]]
 id = "generic-api-key"
 description = "Generic API Key"
-regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z\-_=]{8,64})['\"]'''
+regex = '''(?i)((key|api[^Version]|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z\-_=]{8,64})['\"]'''
 entropy = 3.7
 secretGroup = 4
 


### PR DESCRIPTION
### Description:
Current implementation of the generic-api-key pattern finds plenty of false positives matching `apiVersion` (very popular Kubernetes keyword):
```
"Description": "Generic API Key",
"Match": "apiVersion: '2010-03-31'",
```
this change is to ignore the `apiVersion` string during secret lookup.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
