### PR TITLE
limit number of goroutines for historic scanning as well

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -17,6 +17,8 @@ type Options struct {
 	Redact  bool
 }
 
+const MAXGOROUTINES = 4
+
 func DetectFindings(cfg config.Config, b []byte, filePath string, commit string) []report.Finding {
 	var findings []report.Finding
 	linePairs := regexp.MustCompile("\n").FindAllIndex(b, -1)


### PR DESCRIPTION
### Description:
I was scanning some large repos and noticed my CPU resources being maxed. `--threads` should probably come back as an option but for now I'm just limiting the number of concurrent goroutines to 4. I'm also moving the channel block above the `go func()` call in `files.go` to avoid spawning unnecessary workers which looked like a memory leak.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
