### PR TITLE
Add segment public api token rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -125,6 +125,7 @@ func main() {
 	configRules = append(configRules, rules.RapidAPIAccessToken())
 	configRules = append(configRules, rules.ReadMe())
 	configRules = append(configRules, rules.RubyGemsAPIToken())
+	configRules = append(configRules, rules.SegmentPublicApiToken())
 	configRules = append(configRules, rules.SendbirdAccessID())
 	configRules = append(configRules, rules.SendbirdAccessToken())
 	configRules = append(configRules, rules.SendGridAPIToken())

--- a/cmd/generate/config/rules/segment.go
+++ b/cmd/generate/config/rules/segment.go
@@ -1,0 +1,25 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func SegmentPublicApiToken() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Segment Public API Token",
+		RuleID:      "segment-public-api-token",
+		SecretGroup: 1,
+		Regex:       generateUniqueTokenRegex(`sgp_[a-zA-Z0-9]{64}`),
+		Keywords: []string{
+			"sgp_",
+		},
+	}
+
+	// validate
+	tps := []string{
+		generateSampleSecret("segment", "sgp_"+secrets.NewSecret(alphaNumeric("64"))),
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -489,9 +489,6 @@ keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",
 ]
 [rules.allowlist]
-paths = [
-  '''Database.refactorlog'''
-]
 stopwords= [
     "client",
     "endpoint",
@@ -2450,6 +2447,15 @@ regex = '''(?i)\b(rubygems_[a-f0-9]{48})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
 keywords = [
     "rubygems_",
+]
+
+[[rules]]
+description = "Segment Public API Token"
+id = "segment-public-api-token"
+regex = '''(?i)\b(sgp_[a-zA-Z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
+keywords = [
+    "sgp_",
 ]
 
 [[rules]]


### PR DESCRIPTION
### Description:
This PR adds a rule for [Segment's Public API token](https://api.segmentapis.com/docs/). The token follows the following pattern: `sgp_[a-zA-Z0-9]{64}`. 

Tested locally against a mock repo (I modified the output below with <REDACTED> just to be extra cautious 😄 ):
```
./gitleaks detect -c config/gitleaks.toml -s ../test -v                                                                                                                                                                                    4:28 PM

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks 

{
        "Description": "Segment public API token",
        "StartLine": 21,
        "EndLine": 21,
        "StartColumn": 20,
        "EndColumn": 87,
        "Match": "sgp_<REDACTED>",
        "Secret": "sgp_<REDACTED>",
        "File": "test.go",
        "Commit": "95a9e9f759351e8fa0261938817500cbe5cc8ec6",
        "Entropy": 0,
        "Author": "Sal Olivares",
        "Email": "<REDACTING>",
        "Date": "2022-01-19T00:26:23Z",
        "Message": "initial commit",
        "Tags": [],
        "RuleID": "segment-public-api-token"
}
4:31PM WRN leaks found: 1
4:31PM INF scan completed in 54.693552ms
```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
