### PR TITLE
Sarif results with empty rules now represents as [] instead of null/nil

### DIFF
--- a/report/sarif.go
+++ b/report/sarif.go
@@ -30,13 +30,24 @@ func getRuns(cfg config.Config, findings []Finding) []Runs {
 }
 
 func getTool(cfg config.Config) Tool {
-	return Tool{
+	tool := Tool{
 		Driver: Driver{
 			Name:            driver,
 			SemanticVersion: version,
 			Rules:           getRules(cfg),
 		},
 	}
+
+	// if this tool has no rules, ensure that it is represented as [] instead of null/nil
+	if hasEmptyRules(tool) {
+		tool.Driver.Rules = make([]Rules, 0)
+	}
+
+	return tool
+}
+
+func hasEmptyRules(tool Tool) bool {
+	return len(tool.Driver.Rules) == 0
 }
 
 func getRules(cfg config.Config) []Rules {


### PR DESCRIPTION
### Description:
Fixed the bug where sarif tests with empty config files set their rules fields to null.  these fields now have a value of [] when there is no config file.

REASON FOR BUG -- json.Encoder() handles empty slices in a strange way.  By default, this function sets empty slices to null (I have no idea why this is the default, seems like a poor decision IMO).  If you want an empty slice in a json object you must state that explicitly with the below syntax:

```
tool.Driver.Rules = make([]Rules, 0)
```

TESTING EXPLANATION -- As noted below, I did not add a unit test for this functionality due to the current sarif tests being commented out and I didn't want to change the testing schema.  However, I did manually test by commenting out the line in the tests that delete the temporary test result files and checking that the rules value was indeed [] where appropriate

### Checklist:

* [X] Does your PR pass tests?
* [x] Have you written new tests for your changes? (not done due to current testing structure)
* [X] Have you lint your code locally prior to submission?
