### PR TITLE
use official docker image as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,10 @@
   entry: gitleaks protect --verbose --redact --staged
   language: golang
   pass_filenames: false
+- id: gitleaks-docker
+  name: Detect hardcoded secrets
+  description: Detect hardcoded secrets using Gitleaks
+  entry: zricethezav/gitleaks:v8.5.1
+  language: docker_image
+  types: ["dockerfile"]
+  


### PR DESCRIPTION


### Description:
ability to use the [official docker image](https://github.com/zricethezav/gitleaks#docker=) as [pre-commit hook](https://github.com/zricethezav/gitleaks#pre-commit)

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
