### PR TITLE
use official docker image as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,5 +7,5 @@
 - id: gitleaks-docker
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: zricethezav/gitleaks:v8.5.1 gitleaks protect --verbose --redact --staged
+  entry: zricethezav/gitleaks:v8.5.1 protect --verbose --redact --staged
   language: docker_image

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 - id: gitleaks-docker
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: zricethezav/gitleaks:v8.5.1 gitleaks
+  entry: zricethezav/gitleaks:v8.5.1 gitleaks protect --verbose --redact --staged
   language: docker_image
   types: ["dockerfile"]
   

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,10 @@
   entry: gitleaks protect --verbose --redact --staged
   language: golang
   pass_filenames: false
+- id: gitleaks-docker
+  name: Detect hardcoded secrets
+  description: Detect hardcoded secrets using Gitleaks
+  entry: zricethezav/gitleaks:v8.5.1
+  language: docker_image
+  types: ["dockerfile"]
+  

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,5 +9,3 @@
   description: Detect hardcoded secrets using Gitleaks
   entry: zricethezav/gitleaks:v8.5.1 gitleaks protect --verbose --redact --staged
   language: docker_image
-  types: ["dockerfile"]
-  

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,5 +7,5 @@
 - id: gitleaks-docker
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: zricethezav/gitleaks:v8.5.1 protect --verbose --redact --staged
+  entry: zricethezav/gitleaks:v8.5.2 protect --verbose --redact --staged
   language: docker_image

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 - id: gitleaks-docker
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: zricethezav/gitleaks:v8.5.1
+  entry: zricethezav/gitleaks:v8.5.1 gitleaks
   language: docker_image
   types: ["dockerfile"]
   


### PR DESCRIPTION
### Description:
Use the [official Docker image](https://github.com/zricethezav/gitleaks#docker=) as a [pre-commit hook](https://github.com/zricethezav/gitleaks#pre-commit). Inspired by [hadolint pre-commit hook](https://github.com/hadolint/hadolint/blob/master/.pre-commit-hooks.yaml).

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

I have tested this by adding the following snippet to `.pre-commit-config.yaml`

```yaml
  - repo: https://github.com/zricethezav/gitleaks
    rev: 347f6236f1ec87ddded4c4d450f45c5eb231cccb  # only for testing
    hooks:
      - id: gitleaks-docker
```