### PR TITLE
unpin docker version in pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,5 +7,5 @@
 - id: gitleaks-docker
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: zricethezav/gitleaks:v8.5.2 protect --verbose --redact --staged
+  entry: zricethezav/gitleaks protect --verbose --redact --staged
   language: docker_image


### PR DESCRIPTION
### Description:
eliminating inconsistency. e.g. for version 8.6.1, pre-commit hooks points to outdated version https://github.com/zricethezav/gitleaks/blob/c33ee3f25215635c0afbb210672779e7efb6f1d2/.pre-commit-hooks.yaml#L10.

unpinning the version from the docker hook, behaves in the same manner as the native hook.
this is not the best approach, since each version will pull the latest docker image but will also run on the latest version that is installed on the operating system. the best way to handle the issue is to pin the exact version with each release.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
