### PR TITLE
config: better secret detection in bash scripts

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -627,7 +627,7 @@ keywords = ["tpf_"]
 [[rules]]
 id = "generic-api-key"
 description = "Generic API Key"
-regex = '''(?i)((key|api[^Version]|token|secret|password|auth)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z\-_=]{8,64})['\"]'''
+regex = '''(?i)((key|api[^Version]|token|secret|password|passwd|auth)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]?([0-9a-zA-Z\-_=]{8,64})['\"]?'''
 entropy = 3.7
 secretGroup = 4
 keywords = [


### PR DESCRIPTION
### Description:
in bash, these assignments are equivalent (below), so the apostrophe and quotation marks should be optional
also, very often `passwd` variable name is used


`PASSWORD="secret"`
`PASSWORD='secret'`
`PASSWORD=secret`


### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
