### PR TITLE
Allowlist checks before extracting from a secret group

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -194,7 +194,13 @@ func (d *Detector) detectRule(fragment Fragment, rule *config.Rule) []report.Fin
 			gitleaksAllowSignature) {
 			continue
 		}
-
+		
+		// check if the secret is in the allowlist
+		if rule.Allowlist.RegexAllowed(finding.Secret) ||
+			d.Config.Allowlist.RegexAllowed(finding.Secret) {
+			continue
+		}
+		
 		// extract secret from secret group if set
 		if rule.SecretGroup != 0 {
 			groups := rule.Regex.FindStringSubmatch(secret)
@@ -204,12 +210,6 @@ func (d *Detector) detectRule(fragment Fragment, rule *config.Rule) []report.Fin
 			}
 			secret = groups[rule.SecretGroup]
 			finding.Secret = secret
-		}
-
-		// check if the secret is in the allowlist
-		if rule.Allowlist.RegexAllowed(finding.Secret) ||
-			d.Config.Allowlist.RegexAllowed(finding.Secret) {
-			continue
 		}
 
 		// check entropy


### PR DESCRIPTION
### Description:

Current implementation checks if the secret is in the allowlist when the secret has been extracted from the secret group. As a result, it does not allow ignoring FP cases based on variable names in generic-based rules. For example, I can't exclude findings like `TokenSpec tspec = PKCS8EncodedTokenSpec` using the following rule:

```toml
regex = '''(?i)(token)(.{0,16})([0-9a-zA-Z]{8,64})'''
entropy = 3.7
secretGroup = 3

[rules.allowlist]
    regexes = [
        '''(?i)tokenspec'''
   ]
```

The PR swaps checking and extraction that allows such rules. So, if you only need to check the secret from the secret group you can write regex in the allowlist section.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
