### PR TITLE
Fix generic-api-key detected erroneously (zricethezav#877)

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2221,4 +2221,5 @@ stopwords= [
     "boot",
     "book",
     "branch",
+    "combination",
 ]


### PR DESCRIPTION
### Description:
Add "combination" to stopword list to eliminate a false positive.

### Checklist:

* [ X] Does your PR pass tests? No. I'm not sure where to add a proper test.
* [X ] Have you written new tests for your changes? No.
* [ X] Have you lint your code locally prior to submission? Simple change that does not require linting.
