### PR TITLE
ignore end line when comparing generic rules

### DIFF
--- a/detect/utils.go
+++ b/detect/utils.go
@@ -65,7 +65,6 @@ func filter(findings []report.Finding, redact bool) []report.Finding {
 		if strings.Contains(strings.ToLower(f.RuleID), "generic") {
 			for _, fPrime := range findings {
 				if f.StartLine == fPrime.StartLine &&
-					f.EndLine == fPrime.EndLine &&
 					f.Commit == fPrime.Commit &&
 					f.RuleID != fPrime.RuleID &&
 					strings.Contains(fPrime.Secret, f.Secret) &&


### PR DESCRIPTION
### Description:
This change will remove duplicate findings in some cases. Ex:

```
aws_secret= "AKIAIMNOJVGFDXXXE4OA
```
would report a generic secret and AWS secret because the generic secret currently considered the EOF or end of buffer as a new line. I'll fix that behavior in a subsequent PR.

### Checklist:

* [x] Does your PR pass tests?
* [-] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
