### PR TITLE
Fix duplicate TOML Rules and IDs 

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -299,14 +299,6 @@ keywords = [
 ]
 
 [[rules]]
-description = "Finicity Secret Key"
-id = "flutterwave-public-key"
-regex = '''FLWSECK_TEST-(?i)[a-h0-9]{32}-X'''
-keywords = [
-    "flwseck_test",
-]
-
-[[rules]]
 description = "Frame.io API token"
 id = "frameio-api-token"
 regex = '''fio-u-(?i)[a-z0-9\-_=]{64}'''

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -183,7 +183,7 @@ keywords = [
 
 [[rules]]
 description = "Dropbox API secret"
-id = "doppler-api-token"
+id = "dropbox-api-token"
 regex = '''(?i)(?:dropbox)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{15})(?:['|\"|\n|\r|\s|\x60]|$)'''
 secretGroup = 1
 keywords = [
@@ -292,7 +292,7 @@ keywords = [
 
 [[rules]]
 description = "Finicity Secret Key"
-id = "flutterwave-public-key"
+id = "flutterwave-secret-key"
 regex = '''FLWSECK_TEST-(?i)[a-h0-9]{32}-X'''
 keywords = [
     "flwseck_test",


### PR DESCRIPTION
### Description:
When ingesting the `gitleaks.toml` I noticed a couple of duplicate Rule IDs and a duplicate rule.
This PR removes the duplicate rule and creates a new IDs for each duplicate ID.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
