### PR TITLE
Lint python pre-commit script to satisfy PEP8

### DIFF
--- a/scripts/pre-commit.py
+++ b/scripts/pre-commit.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
-import os,sys
+"""Helper script to be used as a pre-commit hook."""
+import os
+import sys
 import subprocess
 
+
 def gitleaksEnabled():
+    """Determine if the pre-commit hook for gitleaks is enabled."""
     out = subprocess.getoutput("git config --bool hooks.gitleaks")
     if out == "false":
         return False
     return True
+
 
 if gitleaksEnabled():
     exitCode = os.WEXITSTATUS(os.system('gitleaks protect -v --staged'))
@@ -18,5 +23,5 @@ To disable the gitleaks precommit hook run the following command:
 ''')
         sys.exit(1)
 else:
-    print('gitleaks precommit disabled (enable with `git config hooks.gitleaks true`)')
-
+    print('gitleaks precommit disabled\
+     (enable with `git config hooks.gitleaks true`)')


### PR DESCRIPTION
### Description:
Lint the Python script to satisfy [PEP8](https://peps.python.org/pep-0008/).

```
> git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
> flake8 .
./scripts/pre-commit.py:1:1: D100 Missing docstring in public module
./scripts/pre-commit.py:2:10: E401 multiple imports on one line
./scripts/pre-commit.py:2:10: E231 missing whitespace after ','
./scripts/pre-commit.py:5:1: D103 Missing docstring in public function
./scripts/pre-commit.py:5:1: E302 expected 2 blank lines, found 1
./scripts/pre-commit.py:11:1: E305 expected 2 blank lines after class or function definition, found 1
./scripts/pre-commit.py:21:80: E501 line too long (87 > 79 characters)
./scripts/pre-commit.py:22:1: W391 blank line at end of file
> git switch pep8
Switched to branch 'pep8'
> flake8 .
>
```

### Checklist:

* [x] Does your PR pass tests? - **Unchanged.**
* [x] Have you written new tests for your changes? - **N/A**
* [x] Have you lint your code locally prior to submission? - **That's kind of the whole point :)**
