### PR TITLE
Add new rules for vault tokens

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -142,6 +142,8 @@ func main() {
 	configRules = append(configRules, rules.TwitterAccessSecret())
 	configRules = append(configRules, rules.TwitterBearerToken())
 	configRules = append(configRules, rules.Typeform())
+	configRules = append(configRules, rules.VaultBatchToken())
+	configRules = append(configRules, rules.VaultServiceToken())
 	configRules = append(configRules, rules.YandexAPIKey())
 	configRules = append(configRules, rules.YandexAWSAccessToken())
 	configRules = append(configRules, rules.YandexAccessToken())

--- a/cmd/generate/config/rules/vault.go
+++ b/cmd/generate/config/rules/vault.go
@@ -10,7 +10,7 @@ func VaultServiceToken() *config.Rule {
 	r := config.Rule{
 		Description: "Vault Service Token",
 		RuleID:      "vault-service-token",
-		Regex:       generateUniqueTokenRegex(`hvs\.[a-z0-9_-]{90,}`),
+		Regex:       generateUniqueTokenRegex(`hvs\.[a-z0-9_-]{90,100}`),
 		Keywords:    []string{"hvs"},
 	}
 
@@ -26,7 +26,7 @@ func VaultBatchToken() *config.Rule {
 	r := config.Rule{
 		Description: "Vault Batch Token",
 		RuleID:      "vault-batch-token",
-		Regex:       generateUniqueTokenRegex(`hvb\.[a-z0-9_-]{138,}`),
+		Regex:       generateUniqueTokenRegex(`hvb\.[a-z0-9_-]{138,212}`),
 		Keywords:    []string{"hvb"},
 	}
 

--- a/cmd/generate/config/rules/vault.go
+++ b/cmd/generate/config/rules/vault.go
@@ -1,0 +1,38 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func VaultServiceToken() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Vault Service Token",
+		RuleID:      "vault-service-token",
+		Regex:       generateUniqueTokenRegex(`hvs\.[a-z0-9_-]{90,}`),
+		Keywords:    []string{"hvs"},
+	}
+
+	// validate
+	tps := []string{
+		generateSampleSecret("vault", "hvs."+secrets.NewSecret(alphaNumericExtendedShort("90"))),
+	}
+	return validate(r, tps, nil)
+}
+
+func VaultBatchToken() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Vault Batch Token",
+		RuleID:      "vault-batch-token",
+		Regex:       generateUniqueTokenRegex(`hvb\.[a-z0-9_-]{138,}`),
+		Keywords:    []string{"hvb"},
+	}
+
+	// validate
+	tps := []string{
+		generateSampleSecret("vault", "hvb."+secrets.NewSecret(alphaNumericExtendedShort("138"))),
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -1101,6 +1101,22 @@ keywords = [
 ]
 
 [[rules]]
+description = "Vault Batch Token"
+id = "vault-batch-token"
+regex = '''(?i)\b(hvb\.[a-z0-9_-]{138,})(?:['|\"|\n|\r|\s|\x60]|$)'''
+keywords = [
+    "hvb",
+]
+
+[[rules]]
+description = "Vault Service Token"
+id = "vault-service-token"
+regex = '''(?i)\b(hvs\.[a-z0-9_-]{90,})(?:['|\"|\n|\r|\s|\x60]|$)'''
+keywords = [
+    "hvs",
+]
+
+[[rules]]
 description = "Yandex API Key"
 id = "yandex-api-key"
 regex = '''(?i)(?:yandex)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['|\"|\n|\r|\s|\x60]|$)'''

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2589,7 +2589,7 @@ keywords = [
 [[rules]]
 description = "Vault Batch Token"
 id = "vault-batch-token"
-regex = '''(?i)\b(hvb\.[a-z0-9_-]{138,})(?:['|\"|\n|\r|\s|\x60]|$)'''
+regex = '''(?i)\b(hvb\.[a-z0-9_-]{138,212})(?:['|\"|\n|\r|\s|\x60]|$)'''
 keywords = [
     "hvb",
 ]
@@ -2597,7 +2597,7 @@ keywords = [
 [[rules]]
 description = "Vault Service Token"
 id = "vault-service-token"
-regex = '''(?i)\b(hvs\.[a-z0-9_-]{90,})(?:['|\"|\n|\r|\s|\x60]|$)'''
+regex = '''(?i)\b(hvs\.[a-z0-9_-]{90,100})(?:['|\"|\n|\r|\s|\x60]|$)'''
 keywords = [
     "hvs",
 ]


### PR DESCRIPTION
### Description:
This MR adds new rules for HashiCorp Vault tokens.

A few months ago rules for these kind of tokens were [added to the GitLab Secret Detection configuration](https://gitlab.com/gitlab-org/security-products/analyzers/secrets/-/merge_requests/133). But that change had to be [reverted](https://gitlab.com/gitlab-org/security-products/analyzers/secrets/-/merge_requests/137) because there we too many false-positives.

Since then HashiCorp Vault changed the token format to use longer tokens and - most important - a longer prefix:
| Token Type | Vault 1.9 or earlier | Vault 1.10 and later |
|---|---|---|
| Service Tokens | `s.` | `hvs.` |
| Batch Tokens | `b.` |  `hvb.` |
| Recovery Tokens* | `r.` | `hvr.` |

(* I have no idea about recovery tokens - that's why I did not include them here.)

See the [release notes](https://github.com/hashicorp/vault/releases/tag/v1.10.0), the [merge request](https://github.com/hashicorp/vault/pull/14109) or the [docs](https://learn.hashicorp.com/tutorials/vault/tokens#token-prefix) for more information about this.

Here are some example tokens:
```
hvs.CAESIJRM-T1q5lEjIWux1Tjx-VGqAYJdd4FZtbp1wpD5Ym9pGh4KHGh2cy5TSjRndGoxaU44NzNscm5MSlRLQXZ0ZGg
hvs.CAESIKm9l1iEANU2bcrf6zMsvp9MssvZsw6_ccWgT1M5vpqxGh4KHGh2cy5LVjd1dzdQb0pteER1M3ZEb2NwT0hUSGw
hvs.CAESIE9KDBIquhf-9CBrSzq77fKJYGZ6BMzpfmW2AU1I1zleGh4KHGh2cy5SUkxpRDFNcEFsbERSUEkxbEdSalhFdWI

hvb.AAAAAQJyBEVE-vTWUrg0hcoIPuvKjjNxXXZ5MfsYVg2gJ0fGZpVi0IGTFfh4TqsoQIWaocNRXD1qzGXvhIHWJBM_rWU9YJY8sXOYVy_s1JAHasXJwGmZ_fBLJfSG6aCwQkCGwtAhYw
```

I am not sure if the regexes could be extended to check for `CAESI` and `AAAAAQ` - as far as I can tell there is no detailed documentation about the token formats.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
