### PR TITLE
refactor: more precise rule for private keys

### DIFF
--- a/cmd/generate/config/rules/privatekey.go
+++ b/cmd/generate/config/rules/privatekey.go
@@ -11,7 +11,7 @@ func PrivateKey() *config.Rule {
 	r := config.Rule{
 		Description: "Private Key",
 		RuleID:      "private-key",
-		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY-----[\s\S-]*KEY----`),
+		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY----`),
 		Keywords:    []string{"-----BEGIN"},
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2321,7 +2321,7 @@ keywords = [
 [[rules]]
 description = "Private Key"
 id = "private-key"
-regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY-----[\s\S-]*KEY----'''
+regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY'''
 keywords = [
     "-----begin",
 ]

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2321,7 +2321,7 @@ keywords = [
 [[rules]]
 description = "Private Key"
 id = "private-key"
-regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY'''
+regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY----'''
 keywords = [
     "-----begin",
 ]


### PR DESCRIPTION
### Description:
The current regex didn't match PGP private keys anymore, since they start with `BEGIN PGP PRIVATE KEY BLOCK` and the `BLOCK` never matched for the existing regex. I've made that part optional so that all strings matching for the current regex will still match for the new regex.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
