### PR TITLE
Issue 962: Decrease Minimum Regex String Match for Generic Credential & Include Special Characters

### DIFF
--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -19,7 +19,7 @@ func GenericCredential() *config.Rule {
 			"password",
 			"auth",
 			"access",
-		}, `[0-9a-z\-_.=]{10,150}`),
+		}, `[0-9a-z\-_.=@!#$%^&*()<>]{8,150}`),
 		SecretGroup: 1,
 		Keywords: []string{
 			"key",
@@ -32,7 +32,7 @@ func GenericCredential() *config.Rule {
 			"auth",
 			"access",
 		},
-		Entropy: 3.5,
+		Entropy: 2.74,
 		Allowlist: config.Allowlist{
 			StopWords: DefaultStopWords,
 		},
@@ -44,6 +44,8 @@ func GenericCredential() *config.Rule {
 		generateSampleSecret("generic", "Zf3D0LXCM3EIMbgJpUNnkRtOfOueHznB"),
 		`"client_id" : "0afae57f3ccfd9d7f5767067bc48b30f719e271ba470488056e37ab35d4b6506"`,
 		`"client_secret" : "6da89121079f83b2eb6acccf8219ea982c3d79bccc3e9c6a85856480661f8fde",`,
+		generateSampleSecret("generic", "p@55w0rd"),
+		generateSampleSecret("generic", "a1@!#$%^&*()-_<>"),
 	}
 	fps := []string{
 		`client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.client-vpn-endpoint.id`,

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -455,9 +455,9 @@ keywords = [
 [[rules]]
 description = "Generic API Key"
 id = "generic-api-key"
-regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=@!#$%^&*()<>]{8,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
-entropy = 3.5
+entropy = 2.74
 keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",
 ]


### PR DESCRIPTION
[Issue 962](https://github.com/zricethezav/gitleaks/issues/962)

### Description:
Decreases min secret length to 8, to catch common dumb secrets like password / p@55w0rd /etc:
`[0-9a-z\-_.=]{10,150}` -> `[0-9a-z\-_.=]{8,150}`
- Note: the entropy for generic credential needed to be decreased to 2.74 to catch secrets with a length of 8.

Adds special characters to generic credential regex to catch secrets that use those:
`[0-9a-z\-_.=@!#$%^&*()<>]{8,150}`

Added 2 more tests for generic credential
```
		generateSampleSecret("generic", "p@55w0rd"),
		generateSampleSecret("generic", "a1@!#$%^&*()-_<>"),
```

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
