### PR TITLE
Add rule for microsoft teams webhooks

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -141,6 +141,7 @@ func main() {
 	configRules = append(configRules, rules.SquareSpaceAccessToken())
 	configRules = append(configRules, rules.SumoLogicAccessID())
 	configRules = append(configRules, rules.SumoLogicAccessToken())
+	configRules = append(configRules, rules.TeamsWebhook())
 	configRules = append(configRules, rules.TravisCIAccessToken())
 	configRules = append(configRules, rules.Twilio())
 	configRules = append(configRules, rules.TwitchAPIToken())

--- a/cmd/generate/config/rules/teams.go
+++ b/cmd/generate/config/rules/teams.go
@@ -1,0 +1,29 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func TeamsWebhook() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Microsoft Teams Webhook",
+		RuleID:      "microsoft-teams-webhook",
+		Regex: regexp.MustCompile(
+			`https:\/\/[a-z0-9]+\.webhook\.office\.com\/webhookb2\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\/IncomingWebhook\/[a-z0-9]{32}\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}`),
+		Keywords: []string{
+			"webhook.office.com",
+			"webhookb2",
+			"IncomingWebhook",
+		},
+	}
+
+	// validate
+	tps := []string{
+		"https://mycompany.webhook.office.com/webhookb2/" + secrets.NewSecret(`[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\/IncomingWebhook\/[a-z0-9]{32}\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}`), // gitleaks:allow
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2228,6 +2228,14 @@ keywords = [
 ]
 
 [[rules]]
+description = "Microsoft Teams Webhook"
+id = "microsoft-teams-webhook"
+regex = '''https:\/\/[a-z0-9]+\.webhook\.office\.com\/webhookb2\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\/IncomingWebhook\/[a-z0-9]{32}\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}'''
+keywords = [
+    "webhook.office.com","webhookb2","incomingwebhook",
+]
+
+[[rules]]
 description = "Netlify Access Token"
 id = "netlify-access-token"
 regex = '''(?i)(?:netlify)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40,46})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION
### Description:
This MR adds a new rule for Microsoft Teams Webhooks.

The regex is based on the one suggested in #626. The only other information about the URL format I was able to find is from [this stackoverflow article](https://stackoverflow.com/a/69181338).

I confirmed the format locally in our Teams instance and tested the new rule:
`$ gitleaks detect --config gitleaks.toml --no-git` 
<details>
  <summary>Log</summary>

```
{
        "Description": "Microsoft Teams Webhook",
        "StartLine": 2,
        "EndLine": 2,
        "StartColumn": 12,
        "EndColumn": 223,
        "Match": "https://[redacted].webhook.office.com/webhookb2/50koqw9j-e63t-pbul-7rtz-r7hd8jwzhc2l@yj49lqsq-ydkp-xwwv-v0et-6jmvc301riid/IncomingWebhook/aruuzufctr6c5m27tg5ramvhw8jkisdn/v9azwg44-z1m5-9zfl-00rf-1h260d1wnre2",
        "Secret": "https://[redacted].webhook.office.com/webhookb2/50koqw9j-e63t-pbul-7rtz-r7hd8jwzhc2l@yj49lqsq-ydkp-xwwv-v0et-6jmvc301riid/IncomingWebhook/aruuzufctr6c5m27tg5ramvhw8jkisdn/v9azwg44-z1m5-9zfl-00rf-1h260d1wnre2",
        "File": "README.txt",
        "Commit": "",
        "Entropy": 4.68221,
        "Author": "",
        "Email": "",
        "Date": "",
        "Message": "",
        "Tags": [],
        "RuleID": "microsoft-teams-webhook"
}
scan completed in 11.5429ms
leaks found: 1
```
</details>

This closes #626 
This supersedes #918 

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

cc @zricethezav 