### PR TITLE
Add pre-commit autoupdate command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,16 @@ jobs:
    ```
    repos:
      - repo: https://github.com/zricethezav/gitleaks
-       rev: v8.11.2
+       rev: v8.12.0
        hooks:
          - id: gitleaks
    ```
 
    for a [native execution of GitLeaks](https://github.com/zricethezav/gitleaks/releases) or use the [`gitleaks-docker` pre-commit ID](https://github.com/zricethezav/gitleaks/blob/master/.pre-commit-hooks.yaml) for executing GitLeaks using the [official Docker images](#docker)
 
-3. Install with `pre-commit install`
-4. Now you're all set!
+3. Auto-update the config to the latest repos' versions by executing `pre-commit autoupdate`
+4. Install with `pre-commit install`
+5. Now you're all set!
 
 ```
 ➜ git commit -m "this commit contains a secret"


### PR DESCRIPTION
resolves #977 

### Description:

Suggesting a mechanism for a user to always get the latest version of `gitleaks` via the `pre-commit` installation method.

The `pre-commit autoupdate` command will automatically update the version of repos' in the `.pre-commit-config.yaml` file for the user, even if he/she has copied the older version from the README.md.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
