### PR TITLE
Issue #980: Add support for Telegram Bot API Token

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -141,6 +141,7 @@ func main() {
 	configRules = append(configRules, rules.SquareSpaceAccessToken())
 	configRules = append(configRules, rules.SumoLogicAccessID())
 	configRules = append(configRules, rules.SumoLogicAccessToken())
+	configRules = append(configRules, rules.TelegramBotToken())
 	configRules = append(configRules, rules.TravisCIAccessToken())
 	configRules = append(configRules, rules.Twilio())
 	configRules = append(configRules, rules.TwitchAPIToken())

--- a/cmd/generate/config/rules/telegram.go
+++ b/cmd/generate/config/rules/telegram.go
@@ -1,9 +1,7 @@
 package rules
 
 import (
-	"math/rand"
 	"regexp"
-	"strconv"
 
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
@@ -26,18 +24,34 @@ func TelegramBotToken() *config.Rule {
 	}
 
 	// validate
-	token := secrets.NewSecret(numeric(strconv.Itoa(rand.Intn(11)+5)) + ":A" + alphaNumericExtendedShort("34"))
+	validToken := secrets.NewSecret(numeric("8") + ":A" + alphaNumericExtendedShort("34"))
+	minToken := secrets.NewSecret(numeric("5") + ":A" + alphaNumericExtendedShort("34"))
+	maxToken := secrets.NewSecret(numeric("16") + ":A" + alphaNumericExtendedShort("34"))
 	tps := []string{
 		// variable assigment
-		generateSampleSecret("telegram", token),
+		generateSampleSecret("telegram", validToken),
 		// URL contaning token
-		generateSampleSecret("url", "https://api.telegram.org/bot"+token+"/sendMessage"),
+		generateSampleSecret("url", "https://api.telegram.org/bot"+validToken+"/sendMessage"),
 		// object constructor
-		`const bot = new Telegraf("` + token + `")`,
+		`const bot = new Telegraf("` + validToken + `")`,
 		// .env
-		`API_TOKEN = ` + token,
+		`API_TOKEN = ` + validToken,
 		// YAML
-		`bot: ` + token,
+		`bot: ` + validToken,
+		// Token with min bot_id
+		generateSampleSecret("telegram", minToken),
+		// Token with max bot_id
+		generateSampleSecret("telegram", maxToken),
 	}
-	return validate(r, tps, nil)
+
+	tooSmallToken := secrets.NewSecret(numeric("4") + ":A" + alphaNumericExtendedShort("34"))
+	tooBigToken := secrets.NewSecret(numeric("17") + ":A" + alphaNumericExtendedShort("34"))
+	fps := []string{
+		// Token with too small bot_id
+		generateSampleSecret("telegram", tooSmallToken),
+		// Token with too big bot_id
+		generateSampleSecret("telegram", tooBigToken),
+	}
+
+	return validate(r, tps, fps)
 }

--- a/cmd/generate/config/rules/telegram.go
+++ b/cmd/generate/config/rules/telegram.go
@@ -1,0 +1,43 @@
+package rules
+
+import (
+	"math/rand"
+	"regexp"
+	"strconv"
+
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func TelegramBotToken() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Telegram Bot API Token",
+		RuleID:      "telegram-bot-api-token",
+		SecretGroup: 1,
+		Regex:       regexp.MustCompile(`(?i)(?:^|[^0-9])([0-9]{5,16}:A[a-zA-Z0-9_\-]{34})(?:$|[^a-zA-Z0-9_\-])`),
+		Keywords: []string{
+			"telegram",
+			"api",
+			"bot",
+			"token",
+			"url",
+		},
+	}
+
+	// validate
+	token := secrets.NewSecret(numeric(strconv.Itoa(rand.Intn(11)+5)) + ":A" + alphaNumericExtendedShort("34"))
+	tps := []string{
+		// variable assigment
+		generateSampleSecret("telegram", token),
+		// URL contaning token
+		generateSampleSecret("url", "https://api.telegram.org/bot"+token+"/sendMessage"),
+		// object constructor
+		`const bot = new Telegraf("` + token + `")`,
+		// .env
+		`API_TOKEN = ` + token,
+		// YAML
+		`bot: ` + token,
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2578,6 +2578,15 @@ keywords = [
 ]
 
 [[rules]]
+description = "Telegram Bot API Token"
+id = "telegram-bot-api-token"
+regex = '''(?i)(?:^|[^0-9])([0-9]{5,16}:A[a-zA-Z0-9_\-]{34})(?:$|[^a-zA-Z0-9_\-])'''
+secretGroup = 1
+keywords = [
+    "telegram","api","bot","token","url",
+]
+
+[[rules]]
 description = "Travis CI Access Token"
 id = "travisci-access-token"
 regex = '''(?i)(?:travis)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION
### Description:
This MR adds a new rule for Telegram Bot API Token.

It matches a token in the following cases:

- Variable assigment
- Constructor call
- URL containing token
- .env files
- YAML files

It closes #980

### Checklist:

- [x]  Does your PR pass tests?
- [x] Have you written new tests for your changes?
- [x] Have you lint your code locally prior to submission?

cc @zricethezav 