### PR TITLE
Exclude dacpac refactorlogs

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -462,6 +462,9 @@ keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",
 ]
 [rules.allowlist]
+paths = [
+  '''Database.refactorlog'''
+]
 stopwords= [
     "client",
     "endpoint",


### PR DESCRIPTION
### Description:
Dacpac refactorlogs contains Key's that are false positives. This commit excludes those files.

Example file: 

```xml
<?xml version="1.0" encoding="utf-8"?>
<Operations Version="1.0" xmlns=http://schemas.microsoft.com/sqlserver/dac/Serialization/2012/02>
  <Operation Name="Rename Refactor" Key="51452924-8613-4330-a49d-cbbff3dc65a4" ChangeDateTime="12/13/2019 12:44:50">
    <Property Name="ElementName" Value="[Data].[GemeenteImport].[Code]" />
    <Property Name="ElementType" Value="SqlSimpleColumn" />
    <Property Name="ParentElementName" Value="[Data].[GemeenteImport]" />
    <Property Name="ParentElementType" Value="SqlTable" />
    <Property Name="NewName" Value="Totaal" />
  </Operation>  
</Operations>
```
### Checklist:

* [y] Does your PR pass tests?
* [n] Have you written new tests for your changes?
* [n] Have you lint your code locally prior to submission?
