### PR TITLE
Add rule for fine-grained GitHub PAT

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -73,6 +73,7 @@ func main() {
 	// configRules = append(configRules, rules.GCPServiceAccount())
 	configRules = append(configRules, rules.GCPAPIKey())
 	configRules = append(configRules, rules.GitHubPat())
+	configRules = append(configRules, rules.GitHubFineGrainedPat())
 	configRules = append(configRules, rules.GitHubOauth())
 	configRules = append(configRules, rules.GitHubApp())
 	configRules = append(configRules, rules.GitHubRefresh())

--- a/cmd/generate/config/rules/github.go
+++ b/cmd/generate/config/rules/github.go
@@ -23,6 +23,22 @@ func GitHubPat() *config.Rule {
 	return validate(r, tps, nil)
 }
 
+func GitHubFineGrainedPat() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "GitHub Fine-Grained Personal Access Token",
+		RuleID:      "github-fine-grained-pat",
+		Regex:       regexp.MustCompile(`github_pat_[0-9a-zA-Z_]{82}`),
+		Keywords:    []string{"github_pat_"},
+	}
+
+	// validate
+	tps := []string{
+		generateSampleSecret("github", "github_pat_"+secrets.NewSecret(alphaNumeric("82"))),
+	}
+	return validate(r, tps, nil)
+}
+
 func GitHubOauth() *config.Rule {
 	// define rule
 	r := config.Rule{

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -1977,6 +1977,14 @@ keywords = [
 ]
 
 [[rules]]
+description = "GitHub Fine-Grained Personal Access Token"
+id = "github-fine-grained-pat"
+regex = '''github_pat_[0-9a-zA-Z_]{82}'''
+keywords = [
+    "github_pat_",
+]
+
+[[rules]]
 description = "GitHub OAuth Access Token"
 id = "github-oauth"
 regex = '''gho_[0-9a-zA-Z]{36}'''


### PR DESCRIPTION
### Description:
GitHub added a new token format for fine-grained personal access token: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats

I could not find if the format and length of these tokens is documented. I took a sample of 5 tokens to make the regex :shrug: 

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
