### PR TITLE
fix: privatekey suffix between 3 and 5 chars

### DIFF
--- a/cmd/generate/config/rules/privatekey.go
+++ b/cmd/generate/config/rules/privatekey.go
@@ -11,7 +11,7 @@ func PrivateKey() *config.Rule {
 	r := config.Rule{
 		Description: "Private Key",
 		RuleID:      "private-key",
-		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY----`),
+		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY-{3,5}`),
 		Keywords:    []string{"-----BEGIN"},
 	}
 


### PR DESCRIPTION
### Description:

Currently the Regex match for privatekeys only matches 4 "-" characters, but private keys typically end with 5 "-" characters.

I think the current behavior might actual be useful in detecting keys where there last characters has been accidentally ommited, but its a bit of an edge case.

I was using gitleaks to extract private keys from repositories and had issues handling them as they were being parsed out without the final closing "-".  This new signature will greedy match the "-"'s at the end of the key.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
