### PR TITLE
add rule for checking nuget.config passwords

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -110,6 +110,7 @@ func main() {
 	configRules = append(configRules, rules.NewRelicUserKey())
 	configRules = append(configRules, rules.NewRelicBrowserAPIKey())
 	configRules = append(configRules, rules.NPM())
+	configRules = append(configRules, rules.Nuget())
 	configRules = append(configRules, rules.NytimesAccessToken())
 	configRules = append(configRules, rules.OktaAccessToken())
 	configRules = append(configRules, rules.PlaidAccessID())

--- a/cmd/generate/config/rules/nuget.go
+++ b/cmd/generate/config/rules/nuget.go
@@ -1,0 +1,24 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func Nuget() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Nuget Password",
+		RuleID:      "nuget-config-password",
+		Regex:       regexp.MustCompile(`(?i)(<add key=\"(ClearTextPassword)|(Password)\"\s*)(value=\"[A-Za-z0-9]+\"\s*/>)`),
+		SecretGroup: 2,
+		Keywords:    []string{"cleartextpassword", "password"},
+	}
+
+	// validate
+	tps := []string{
+		`<add key="ClearTextPassword" value="nvnmsklavkoneroijvoks894789532ifjklwnfi28ur" />`,
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -489,9 +489,6 @@ keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",
 ]
 [rules.allowlist]
-paths = [
-  '''Database.refactorlog'''
-]
 stopwords= [
     "client",
     "endpoint",
@@ -2316,6 +2313,15 @@ regex = '''(?i)\b(npm_[a-z0-9]{36})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
 keywords = [
     "npm_",
+]
+
+[[rules]]
+description = "Nuget Password"
+id = "nuget-config-password"
+regex = '''(?i)(<add key=\"(ClearTextPassword)|(Password)\"\s*)(value=\"[A-Za-z0-9]+\"\s*/>)'''
+secretGroup = 2
+keywords = [
+    "cleartextpassword","password",
 ]
 
 [[rules]]


### PR DESCRIPTION
### Description:
Currently there is no support for finding private NuGet feed passwords.
Added regex will trigger a leak if Password/ClearTextPassword attributes appears with alphanumeric values.
For more info about NuGet configuration please refer to [MSDN NuGet Config](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file)

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
