### PR TITLE
ignore package-lock.json

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -17,6 +17,7 @@ paths = [
     '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket)$''',
     '''(go.mod|go.sum)$''',
     '''node_modules''',
+    '''package-lock.json''',
     '''vendor''',
 ]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -17,6 +17,7 @@ paths = [
     '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket)$''',
     '''(go.mod|go.sum)$''',
     '''node_modules''',
+    '''package-lock.json''',
     '''vendor''',
 ]
 


### PR DESCRIPTION
`package-lock.json` is automatically generated by npm and can cause a lot of false positives. There should never be secrets in the file because it just lists dependencies and is usually never edited by humans.
