### PR TITLE
Fix: go.mod version changed back to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zricethezav/gitleaks/v8
 
-go 1.19
+go 1.18
 
 require (
 	github.com/charmbracelet/lipgloss v0.5.0


### PR DESCRIPTION
### Description:

Error installing gitleaks from source in amazon linux ec2 instance
There was a go version error in go.mod file "Maximum version supported by tidy is 1.18" but in go.mod it's 1.19.


### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
