### PR TITLE
fix: ignore baseline if path was not relative in source

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -749,4 +749,4 @@ acce01f2338434a78f6a4a06a097b0fd23280484:README.md:aws-access-token:220
 111c8b47b65627db117bd20be85ff0aee8961eb9:detect/detect_test.go:private-key:567
 99d620c719020fa24baa831299f0c964da79875e:detect/detect_test.go:aws-access-token:512
 99d620c719020fa24baa831299f0c964da79875e:detect/detect_test.go:aws-access-token:513
-
+69f161c0a0cc0f7858f7d0609d656f4edcedd84c:detect/detect_test.go:discord-api-token:326

--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -86,7 +86,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 	// ignore findings from the baseline (an existing report in json format generated earlier)
 	baselinePath, _ := cmd.Flags().GetString("baseline-path")
 	if baselinePath != "" {
-		err = detector.AddBaseline(baselinePath)
+		err = detector.AddBaseline(baselinePath, source)
 		if err != nil {
 			log.Error().Msgf("Could not load baseline. The path must point of a gitleaks report generated using the default format: %s", err)
 		}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -160,14 +160,33 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 	return nil
 }
 
-func (d *Detector) AddBaseline(baselinePath string) error {
+func (d *Detector) AddBaseline(baselinePath string, source string) error {
 	if baselinePath != "" {
+		absoluteSource, err := filepath.Abs(source)
+		if err != nil {
+			return err
+		}
+
+		absoluteBaseline, err := filepath.Abs(baselinePath)
+		if err != nil {
+			return err
+		}
+
+		relativeBaseline, err := filepath.Rel(absoluteSource, absoluteBaseline)
+		if err != nil {
+			return err
+		}
+
 		baseline, err := LoadBaseline(baselinePath)
 		if err != nil {
 			return err
 		}
+
 		d.baseline = baseline
+		baselinePath = relativeBaseline
+
 	}
+
 	d.baselinePath = baselinePath
 	return nil
 }

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -18,8 +18,9 @@ const repoBasePath = "../testdata/repos/"
 
 func TestDetect(t *testing.T) {
 	tests := []struct {
-		cfgName  string
-		fragment Fragment
+		cfgName      string
+		baselinePath string
+		fragment     Fragment
 		// NOTE: for expected findings, all line numbers will be 0
 		// because line deltas are added _after_ the finding is created.
 		// I.e, if the finding is from a --no-git file, the line number will be
@@ -318,6 +319,15 @@ func TestDetect(t *testing.T) {
 			},
 			expectedFindings: []report.Finding{},
 		},
+		{
+			cfgName:      "path_only",
+			baselinePath: ".baseline.json",
+			fragment: Fragment{
+				Raw:      `const Discord_Public_Key = "e7322523fb86ed64c836a979cf8465fbd436378c653c1db38f9ae87bc62a6fd5"`,
+				FilePath: ".baseline.json",
+			},
+			expectedFindings: []report.Finding{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -344,6 +354,7 @@ func TestDetect(t *testing.T) {
 			assert.Equal(t, tt.wantError, err)
 		}
 		d := NewDetector(cfg)
+		d.baselinePath = tt.baselinePath
 
 		findings := d.Detect(tt.fragment)
 		assert.ElementsMatch(t, tt.expectedFindings, findings)


### PR DESCRIPTION
### Description:
There is currently a bug with the baseline ignore.

If gitleaks is not executed in the current directory and --source is used to specify a custom path, the baseline file is not ignored correctly because the relative file paths do not match. That check is done in `Detect()`.

This will currently report secrets in the baseline file, however the baseline file should be excluded.
```
gitleaks detect --report-format json --verbose --log-level debug --baseline-path ~/foo/.gitleaks.baseline.json --source ~/foo
```

Basically as for now the baseline only works if gitleaks is executed directly in the target repository and the baseline path is set relative to it.
This pr fixes that bug so the baseline path is resolved correctly and can be compared during fragments check no matter what directory.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
