### PR TITLE
Add pnpm-lock.yaml and Database.refactorlog

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -18,6 +18,8 @@ paths = [
     '''(go.mod|go.sum)$''',
     '''node_modules''',
     '''package-lock.json''',
+    '''pnpm-lock.yaml''',
+    '''Database.refactorlog''',
     '''vendor''',
 ]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -18,6 +18,8 @@ paths = [
     '''(go.mod|go.sum)$''',
     '''node_modules''',
     '''package-lock.json''',
+    '''pnpm-lock.yaml''',
+    '''Database.refactorlog''',
     '''vendor''',
 ]
 
@@ -490,9 +492,6 @@ keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",
 ]
 [rules.allowlist]
-paths = [
-  '''Database.refactorlog'''
-]
 stopwords= [
     "client",
     "endpoint",
@@ -2780,4 +2779,5 @@ secretGroup = 1
 keywords = [
     "zendesk",
 ]
+
 


### PR DESCRIPTION
### Description:
In https://github.com/zricethezav/gitleaks/pull/1076 package-lock.json was added. Some teams use pnpm so the lock file of pnpm also needs to be excluded (pnpm-lock.yaml)

In https://github.com/zricethezav/gitleaks/pull/990 I've submitted Database.refactorlog. This was done directly in the generated file causing problems

### Checklist:

* [X] Does your PR pass tests?
* [ ] Have you written new tests for your changes? --> Not applicable
* [X] Have you lint your code locally prior to submission?
