### PR TITLE
Fix global ignore for jquery/swagger without version

### DIFF
--- a/cmd/generate/config/base/config.go
+++ b/cmd/generate/config/base/config.go
@@ -82,7 +82,7 @@ func CreateGlobalConfig() config.Config {
 				regexp.MustCompile(`(^|/)npm-shrinkwrap\.json$`),
 				regexp.MustCompile(`(^|/)bower_components/.*?$`),
 				// TODO: Add more common static assets, such as swagger-ui.
-				regexp.MustCompile(`(^|/)(jquery(-?ui)?|swagger-?ui)-[a-zA-Z0-9.-]+\.js(\.map)?$`),
+				regexp.MustCompile(`(^|/)(jquery(-?ui)?|swagger-?ui)[a-zA-Z0-9.-]+\.js(\.map)?$`),
 
 				// ----------- Python files -----------
 				// Dependencies and lock files.

--- a/cmd/generate/config/base/config_test.go
+++ b/cmd/generate/config/base/config_test.go
@@ -95,6 +95,7 @@ func TestConfigAllowlistPaths(t *testing.T) {
 				`src/main/resources/static/js/jquery-ui-1.10.4.min.js`,
 				`swagger/swaggerui/swagger-ui-bundle.js.map`,
 				`swagger/swaggerui/swagger-ui-es-bundle.js.map`,
+				`src/main/static/swagger-ui.min.js`,
 			},
 		},
 		"python": {

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -43,7 +43,7 @@ paths = [
     '''(^|/)pnpm-lock\.yaml$''',
     '''(^|/)npm-shrinkwrap\.json$''',
     '''(^|/)bower_components/.*?$''',
-    '''(^|/)(jquery(-?ui)?|swagger-?ui)-[a-zA-Z0-9.-]+\.js(\.map)?$''',
+    '''(^|/)(jquery(-?ui)?|swagger-?ui)[a-zA-Z0-9.-]+\.js(\.map)?$''',
     '''(^|/)(Pipfile|poetry)\.lock$''',
     '''(?i)/?(v?env|virtualenv)/lib(64)?/.+$''',
     '''(?i)(^|/)(lib(64)?/python[23](\.\d{1,2})+/|python/[23](\.\d{1,2})+/lib(64)?/).+$''',


### PR DESCRIPTION
### Description:
This properly skips things like `swagger-ui.min.js`.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
