### PR TITLE
Fix pre-commit hook by use git-agnostic file-based checking 

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,15 +1,18 @@
 - id: gitleaks
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: gitleaks dir --redact --verbose
+  entry: gitleaks dir
+  args: [--redact, --verbose]
   language: golang
 - id: gitleaks-docker
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: zricethezav/gitleaks dir --redact --verbose
+  entry: zricethezav/gitleaks dir
+  args: [--redact, --verbose]
   language: docker_image
 - id: gitleaks-system
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: gitleaks dir --redact --verbose
+  entry: gitleaks dir
+  args: [--redact, --verbose]
   language: system


### PR DESCRIPTION
### Description:

This fixes gitleaks invocations via pre-commit when there are no changed to-be-committed (i.e., via `pre-commit run --files` or `pre-commit run --all-files`). Currently, these will pass even if there would be gitleaks findings because `gitleaks git` checks the diff only.

When called via pre-commit framework, gitleaks does not need to git-aware because the framework already detects which files need to be checked (either the diff when a commit range or changes that are about-to-be-committed are checked, or the files passed to the `--files` command line argument).

Fixes https://github.com/gitleaks/gitleaks/issues/1409.

### Checklist:

* [x] Does your PR pass tests? - unit tests are unaffected, manual testing of pre-commit hook passed
* [x] Have you written new tests for your changes? - not applicable
* [x] Have you lint your code locally prior to submission? - passed my yaml formatter
