### PR TITLE
Update and re-add `GCPServiceAccount` rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -98,8 +98,7 @@ func main() {
 		rules.Freemius(),
 		rules.FreshbooksAccessToken(),
 		rules.GoCardless(),
-		// TODO figure out what makes sense for GCP
-		// rules.GCPServiceAccount(),
+		rules.GCPServiceAccount(),
 		rules.GCPAPIKey(),
 		rules.GitHubPat(),
 		rules.GitHubFineGrainedPat(),

--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -21,18 +21,7 @@ func GCPServiceAccount() *config.Rule {
 		Regex:       regexp.MustCompile(`(?s)\{\s*(?:(?:.*?"type"\s*:\s*"service_account".*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?")|(?:.*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?".*?"type"\s*:\s*"service_account")).*?\}`),
 		Entropy:     5,
 		Keywords: []string{
-			"type",
 			"service_account",
-			"project_id",
-			"private_key_id",
-			"private_key",
-			"client_email",
-			"client_id",
-			"auth_uri",
-			"token_uri",
-			"auth_provider_x509_cert_url",
-			"client_x509_cert_url",
-			"universe_domain",
 		},
 		Tags: []string{
 			"gcp",

--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -16,11 +16,10 @@ import (
 func GCPServiceAccount() *config.Rule {
 	// Define rule metadata.
 	r := config.Rule{
-		Description: "Google (GCP) Service-account",
-		RuleID:      "gcp-service-account",
+		Description: "Discovered a Google Cloud (GCP) service account key file, which comes bundled with a private key and service account information",
+		RuleID:      "gcp-service-account-key",
 		Regex:       regexp.MustCompile(`(?s)\{\s*(?:(?:.*?"type"\s*:\s*"service_account".*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?")|(?:.*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?".*?"type"\s*:\s*"service_account")).*?\}`),
-
-		Entropy: 5,
+		Entropy:     5,
 		Keywords: []string{
 			"type",
 			"service_account",
@@ -54,6 +53,7 @@ func GCPServiceAccount() *config.Rule {
 	lowEntropyKey := strings.Repeat("X", 1500)
 
 	tps := []string{
+		// "type": "service_account" at beginning
 		fmt.Sprintf(
 			`{
 				"type": "service_account",
@@ -68,6 +68,7 @@ func GCPServiceAccount() *config.Rule {
 				"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gitleaks-test%%40%s.iam.gserviceaccount.com",
 				"universe_domain": "googleapis.com"
 			}`, projectId, privateKeyId, privateKey, projectId, clientId, projectId),
+		// "type": "service_account" at end
 		fmt.Sprintf(
 			`{
 					"project_id": "%s",
@@ -95,7 +96,7 @@ func GCPServiceAccount() *config.Rule {
 				"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
 				"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gitleaks-test%%40%s.iam.gserviceaccount.com",
 				"universe_domain": "googleapis.com"
-    	}`, projectId, privateKeyId, projectId, clientId, projectId),
+			}`, projectId, privateKeyId, projectId, clientId, projectId),
 	}
 
 	fps := []string{

--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -1,27 +1,149 @@
 package rules
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
 	"github.com/zricethezav/gitleaks/v8/regexp"
 )
 
-// TODO this one could probably use some work
+// GCPServiceAccount returns a rule for detecting Google Cloud service account credentials.
+// The PrivateKey rule is configured to allow these keys to prevent duplicate findings since
+// Google Cloud Service Account keys contain a private key.
 func GCPServiceAccount() *config.Rule {
-	// define rule
+	// Define rule metadata.
 	r := config.Rule{
 		Description: "Google (GCP) Service-account",
 		RuleID:      "gcp-service-account",
-		Regex:       regexp.MustCompile(`\"type\": \"service_account\"`),
-		Keywords:    []string{`\"type\": \"service_account\"`},
+		Regex:       regexp.MustCompile(`(?s)\{\s*(?:(?:.*?"type"\s*:\s*"service_account".*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?")|(?:.*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?".*?"type"\s*:\s*"service_account")).*?\}`),
+
+		Entropy: 5,
+		Keywords: []string{
+			"type",
+			"service_account",
+			"project_id",
+			"private_key_id",
+			"private_key",
+			"client_email",
+			"client_id",
+			"auth_uri",
+			"token_uri",
+			"auth_provider_x509_cert_url",
+			"client_x509_cert_url",
+			"universe_domain",
+		},
+		Tags: []string{
+			"gcp",
+			"google",
+		},
 	}
 
-	// validate
+	projectId := secrets.NewSecret(`[a-z][-a-z0-9]{4,28}[a-z0-9]{1}`)
+	privateKeyId := secrets.NewSecret(`[a-f0-9]{40}`)
+	clientId := secrets.NewSecret(`[0-9]{21}`)
+	privateKey := secrets.NewSecret(
+		`-----BEGIN PRIVATE KEY-----\n` +
+			`(?:[A-Za-z0-9+/=]{60}\n){10}` +
+			`[A-Za-z0-9+/=]{40}=\n` +
+			`-----END PRIVATE KEY-----\n`,
+	)
+
+	lowEntropyKey := strings.Repeat("X", 1500)
+
 	tps := []string{
-		`"type": "service_account"`,
+		fmt.Sprintf(
+			`{
+				"type": "service_account",
+				"project_id": "%s",
+				"private_key_id": "%s",
+				"private_key": "%s",
+				"client_email": "gitleaks-test@%s.iam.gserviceaccount.com",
+				"client_id": "%s",
+				"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+				"token_uri": "https://oauth2.googleapis.com/token",
+				"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+				"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gitleaks-test%%40%s.iam.gserviceaccount.com",
+				"universe_domain": "googleapis.com"
+			}`, projectId, privateKeyId, privateKey, projectId, clientId, projectId),
+		fmt.Sprintf(
+			`{
+					"project_id": "%s",
+					"private_key_id": "%s",
+					"private_key": "%s",
+					"client_email": "gitleaks-test@%s.iam.gserviceaccount.com",
+					"client_id": "%s",
+					"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+					"token_uri": "https://oauth2.googleapis.com/token",
+					"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+					"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gitleaks-test%%40%s.iam.gserviceaccount.com",
+					"universe_domain": "googleapis.com",
+					"type": "service_account",
+				}`, projectId, privateKeyId, privateKey, projectId, clientId, projectId),
+		fmt.Sprintf(
+			`{
+				"type": "service_account",
+				"project_id": "%s",
+				"private_key_id": "%s",
+				"private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCy1yG25m+cplha\n8h1Jmd9m15gGabp2Uk5B/lgHglYiE+TRH7GvLTg30x9FIoarZR5SLKWaSQ50JPNL\npf5XlmiPmwRyY0hCQvDwPy0xX0iNCO/OGInGT0+oKXDtVb4e3NSp1sAmIVSVYyWg\nlwDl0W28t9rZdRprMTA0NU5GMeTGolsFxjhTp313Ss7iZ6fsg6TDz5Gv1Js0iXyl\nKDj1nIFaokZ7ERTOMGTQ4TTKgHIHhp4fVBsjJp4cKvv48DhabHLyz4zQhfzEK0dj\n2KT2Kkp1GS1JwKRApxHVBPgm55CVsAMLTxHBVgvujcDKavfLLANSWpOZnIiNdbsE\n1BWF/2VtAgMBAAECggEAGvSeGklFTWEtNBgGHg/ZQlEAkwbgmfDx5rSFZCxa+yvw\ncyzJxVOVg6SItAzuK2tEVLJyC30zdoITQbW1TlJXVD3TP8KDI6mfUzbSgvyPnOJZ\n8sB0E7Xklb4ZTUx9KX2zeB3sPFMNwq58/2WDNyCH38f+boReBQYW8+eM8ruWdfHF\nvqm7M+JxiAH1pD/QOqkEo5SdkIUd2Cg6CbvQtLAUx7Daom09zR79OkezZ2+SWFff\n3nG4xnSUPF22UzZQw1gsyduT9p24ibncltlGVvtu/Mv7FAQdAo0gTDozVKGIdNjH\nCFjsEpduwnRFwFxbieKHbTbCBCn9A7PJNIphCyDhaQKBgQDwyw7kwCUbKGIMkcdL\nEKBcIeSJgVVP0kKb9Y4Z9pHqoFfutLzCrOrAYimhRAt86FEbojJJoMEL0o0lSnME\nRSxq5nFXwQSHFMKdOyA+ojlXUiB3f4CEUAxJ44Q6CbbZth7DJyt2cWGSNLB/xAEg\nJyKQb0aDRf/Zfqmsvdj+HLAigwKBgQC+InjfOPek2WsgYqBZr1Td16K/e7W1gOhv\nH033zEbveHkJD11IKzQP5l+6hokFteFG0k2jEB+HK8MxGufgBQ3asbQmYxFRAJFl\nkQKyTrZGvHlPNsGt1vGuj/EF4Vp2ih2dXhoPA8Y0vXc+GyTAnvShSJz5FPJVCHPq\n0MMSSvAVTwKBgCjcPEXC+Uj3fFPntOrfAmc/9RkEUma+JkFy1M9BERfAZ8uA7fsW\n/qrwvWG5Oz3R6lmHF4N4/Ok1rG/kh0n1NwlY22jpvwvxEOk/bERUoOhZblr4zuUk\n9EDhk8GJfnbJOcUh83Ug3k7CFCVKLGq5WVsrFssV6MmOfdprSNQuKBFjAoGBAKWu\n+m9igAJp570X1K1yaNzMLKj5z3UzuNgkile17dZ9v9MSTXI3G64DTUYIOFz+iimh\n1z+SLDco/nXLAWYoYVNCaT7OM2fHu+uqupPQnWv0jy1lBM9Mr9wy2JAMOT10y6u3\nNbQB0PViaQd4tcUYfwoQcaFoDGfm7sQfWO2W2bFnAoGAD5NRuS5/EEqm8dZY6EKw\nbX+7HNBeYDf7A5Uh15TYIu5ckM30sr0rg2/RzrW6qdfD93EwKxc3mAi+zxbA/EnU\nDVQ3n0BNNR2kEzOSXm2uRGRt6EjFlke1YUqVytWlNBi99expsFRxihD996MBfYWJ\nxElNa3RTdwMPGE02C0y7fBg=\n-----END PRIVATE KEY-----\n",
+				"client_email": "gitleaks-test@%s.iam.gserviceaccount.com",
+				"client_id": "%s",
+				"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+				"token_uri": "https://oauth2.googleapis.com/token",
+				"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+				"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gitleaks-test%%40%s.iam.gserviceaccount.com",
+				"universe_domain": "googleapis.com"
+    	}`, projectId, privateKeyId, projectId, clientId, projectId),
 	}
-	return utils.Validate(r, tps, nil)
+
+	fps := []string{
+		// No `"private_key"`
+		fmt.Sprintf(
+			`{
+				"type": "service_account",
+				"project_id": "%s",
+				"private_key_id": "%s",
+				"client_email": "gitleaks-test@%s.iam.gserviceaccount.com",
+				"client_id": "%s",
+				"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+				"token_uri": "https://oauth2.googleapis.com/token",
+				"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+				"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gitleaks-test%%40%s.iam.gserviceaccount.com",
+				"universe_domain": "googleapis.com"
+			}`, projectId, privateKeyId, projectId, clientId, projectId),
+		// No `"type": "service_account"`
+		fmt.Sprintf(
+			`{
+				"project_id": "%s",
+				"private_key_id": "%s",
+				"private_key": "%s",
+				"client_email": "gitleaks-test@%s.iam.gserviceaccount.com",
+				"client_id": "%s",
+				"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+				"token_uri": "https://oauth2.googleapis.com/token",
+				"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+				"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gitleaks-test%%40%s.iam.gserviceaccount.com",
+				"universe_domain": "googleapis.com"
+			}`, projectId, privateKeyId, privateKey, projectId, clientId, projectId),
+		// Low entropy `"private_key"`
+		fmt.Sprintf(
+			`{
+				"type": "service_account",
+				"project_id": "%s",
+				"private_key_id": "%s",
+				"private_key": "-----BEGIN PRIVATE KEY-----%s-----END PRIVATE KEY-----\n",
+				"client_email": "gitleaks-test@%s.iam.gserviceaccount.com",
+				"client_id": "%s",
+				"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+				"token_uri": "https://oauth2.googleapis.com/token",
+				"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+				"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/gitleaks-test%%40%s.iam.gserviceaccount.com",
+				"universe_domain": "googleapis.com"
+    	}`, projectId, privateKeyId, lowEntropyKey, projectId, clientId, projectId),
+	}
+	return utils.Validate(r, tps, fps)
 }
 
 func GCPAPIKey() *config.Rule {

--- a/cmd/generate/config/rules/privatekey.go
+++ b/cmd/generate/config/rules/privatekey.go
@@ -13,6 +13,20 @@ func PrivateKey() *config.Rule {
 		Description: "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption.",
 		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]{64,}?KEY(?: BLOCK)?-----`),
 		Keywords:    []string{"-----BEGIN"},
+		Allowlists: []*config.Allowlist{
+			{
+				Description: "Ignore private keys within GCP service account JSON files to prevent duplicate findings",
+				RegexTarget: "line",
+				Regexes: []*regexp.Regexp{
+					// Match lines that contain service account type declarations unlikely to change
+					regexp.MustCompile(`.*"type":\s*"service_account".*`),
+					regexp.MustCompile(`.*"private_key":\s*"-----BEGIN PRIVATE KEY-----.*`),
+					regexp.MustCompile(`.*"project_id":\s*"[a-z][-a-z0-9]{4,28}[a-z0-9]{1}".*`),
+					regexp.MustCompile(`.*"private_key_id":\s*"[^"]*".*`),
+					regexp.MustCompile(`.*"client_id":\s*"[0-9]+".*`),
+				},
+			},
+		},
 	}
 
 	// validate

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -610,8 +610,8 @@ regexes = [
 ]
 
 [[rules]]
-id = "gcp-service-account"
-description = "Google (GCP) Service-account"
+id = "gcp-service-account-key"
+description = "Discovered a Google Cloud (GCP) service account key file, which comes bundled with a private key and service account information"
 regex = '''(?s)\{\s*(?:(?:.*?"type"\s*:\s*"service_account".*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?")|(?:.*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?".*?"type"\s*:\s*"service_account")).*?\}'''
 entropy = 5
 keywords = [

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -614,20 +614,7 @@ id = "gcp-service-account-key"
 description = "Discovered a Google Cloud (GCP) service account key file, which comes bundled with a private key and service account information"
 regex = '''(?s)\{\s*(?:(?:.*?"type"\s*:\s*"service_account".*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?")|(?:.*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?".*?"type"\s*:\s*"service_account")).*?\}'''
 entropy = 5
-keywords = [
-    "type",
-    "service_account",
-    "project_id",
-    "private_key_id",
-    "private_key",
-    "client_email",
-    "client_id",
-    "auth_uri",
-    "token_uri",
-    "auth_provider_x509_cert_url",
-    "client_x509_cert_url",
-    "universe_domain",
-]
+keywords = ["service_account"]
 tags = [
     "gcp","google",
 ]

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -610,6 +610,29 @@ regexes = [
 ]
 
 [[rules]]
+id = "gcp-service-account"
+description = "Google (GCP) Service-account"
+regex = '''(?s)\{\s*(?:(?:.*?"type"\s*:\s*"service_account".*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?")|(?:.*?"private_key"\s*:\s*"-----BEGIN PRIVATE KEY-----[\s\S-]{64,}?-----END PRIVATE KEY-----[\s\S]*?".*?"type"\s*:\s*"service_account")).*?\}'''
+entropy = 5
+keywords = [
+    "type",
+    "service_account",
+    "project_id",
+    "private_key_id",
+    "private_key",
+    "client_email",
+    "client_id",
+    "auth_uri",
+    "token_uri",
+    "auth_provider_x509_cert_url",
+    "client_x509_cert_url",
+    "universe_domain",
+]
+tags = [
+    "gcp","google",
+]
+
+[[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
 regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passw(?:or)?d|secret|token)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,}={0,3})(?:[\x60'"\s;]|\\[nr]|$)'''
@@ -2749,6 +2772,16 @@ id = "private-key"
 description = "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption."
 regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]{64,}?KEY(?: BLOCK)?-----'''
 keywords = ["-----begin"]
+[[rules.allowlists]]
+description = "Ignore private keys within GCP service account JSON files to prevent duplicate findings"
+regexTarget = "line"
+regexes = [
+    '''.*"type":\s*"service_account".*''',
+    '''.*"private_key":\s*"-----BEGIN PRIVATE KEY-----.*''',
+    '''.*"project_id":\s*"[a-z][-a-z0-9]{4,28}[a-z0-9]{1}".*''',
+    '''.*"private_key_id":\s*"[^"]*".*''',
+    '''.*"client_id":\s*"[0-9]+".*''',
+]
 
 [[rules]]
 id = "privateai-api-token"


### PR DESCRIPTION
### Description:
Closes #1818.

The `GCPServiceAccount` rule has been commented out for some time, most likely due to:
- a `TODO` in `cmd/generate/config/rules/gcp.go` indicating it needs work
- the secrets in question get caught by the `PrivateKey` rule anyway, so it may not have been noticed that it wasn't live, and if it _were_ live the secret findings would get duplicated, making things confusing

This PR:
- Makes the `GCPServiceAccount` rule live
- Includes significant updates to the rule, including validation
- Adds an `Allowlist` to the `PrivateKey` rule which ensures that `GCPServiceAccount` key findings aren't duplicated. They are now only found by the `gcp-service-account` `RuleID`.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
