### PR TITLE
fix(pre-commit): don't pass filenames to system hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,3 +15,4 @@
   description: Detect hardcoded secrets using Gitleaks
   entry: gitleaks git --pre-commit --redact --staged --verbose
   language: system
+  pass_filenames: false


### PR DESCRIPTION
### Description:
2 of the 3 pre-commit hooks don't get filenames passed as arguments to gitleaks. The "system" hook still gets filenames though, and that causes it to fail.

Fixes #1895 
Fixes #1859 

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
