### PR TITLE
Respect contexts with timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,13 @@ Detect hardcoded secrets................................................Skipped
 ## Usage
 
 ```
+Gitleaks scans code, past or present, for secrets
+
 Usage:
   gitleaks [command]
 
 Available Commands:
+  completion  Generate the autocompletion script for the specified shell
   dir         scan directories or files for secrets
   git         scan git repositories for secrets
   help        Help about any command
@@ -161,16 +164,16 @@ Flags:
                                       3. env var GITLEAKS_CONFIG_TOML with the file content
                                       4. (target path)/.gitleaks.toml
                                       If none of the four options are used, then gitleaks will use the default config
-      --diagnostics string            enable diagnostics (comma-separated list: cpu,mem,trace). cpu=CPU profiling, mem=memory profiling, trace=execution tracing
-      --diagnostics-dir string        directory to store diagnostics output files (defaults to current directory)
+      --diagnostics string            enable diagnostics (http OR comma-separated list: cpu,mem,trace). cpu=CPU prof, mem=memory prof, trace=exec tracing, http=serve via net/http/pprof
+      --diagnostics-dir string        directory to store diagnostics output files when not using http mode (defaults to current directory)
       --enable-rule strings           only enable specific rules by id
       --exit-code int                 exit code when leaks have been encountered (default 1)
   -i, --gitleaks-ignore-path string   path to .gitleaksignore file or folder containing one (default ".")
   -h, --help                          help for gitleaks
       --ignore-gitleaks-allow         ignore gitleaks:allow comments
   -l, --log-level string              log level (trace, debug, info, warn, error, fatal) (default "info")
-      --max-decode-depth int          allow recursive decoding up to this depth (default "0", no decoding is done)
       --max-archive-depth int         allow scanning into nested archives up to this depth (default "0", no archive traversal is done)
+      --max-decode-depth int          allow recursive decoding up to this depth (default "0", no decoding is done)
       --max-target-megabytes int      files larger than this will be skipped
       --no-banner                     suppress banner
       --no-color                      turn off color for verbose output
@@ -178,6 +181,7 @@ Flags:
   -f, --report-format string          output format (json, csv, junit, sarif, template)
   -r, --report-path string            report file
       --report-template string        template file used to generate the report (implies --report-format=template)
+      --timeout int                   set a timeout for gitleaks commands in seconds (default "0", no timeout is set)
   -v, --verbose                       show verbose output from scan
       --version                       version for gitleaks
 
@@ -422,7 +426,7 @@ In v8.28.0 Gitleaks introduced composite rules, which are made up of a single "p
 **Proximity matching:** Using the `withinLines` and `withinColumns` fields instructs the primary rule to only report a finding if the auxiliary `required` rules also find matches within the specified proximity. You can set:
 
 - **`withinLines: N`** - required findings must be within N lines (vertically)
-- **`withinColumns: N`** - required findings must be within N characters (horizontally)  
+- **`withinColumns: N`** - required findings must be within N characters (horizontally)
 - **Both** - creates a rectangular search area (both constraints must be satisfied)
 - **Neither** - fragment-level matching (required findings can be anywhere in the same fragment)
 
@@ -434,76 +438,76 @@ a = auxiliary (required) captured secret
 fragment = section of data gitleaks is looking at
 
 
-    *Fragment-level proximity*               
+    *Fragment-level proximity*
     Any required finding in the fragment
-          ┌────────┐                       
-   ┌──────┤fragment├─────┐                 
-   │      └──────┬─┤     │ ┌───────┐       
-   │             │a│◀────┼─│✓ MATCH│       
-   │          ┌─┐└─┘     │ └───────┘       
-   │┌─┐       │p│        │                 
-   ││a│    ┌─┐└─┘        │ ┌───────┐       
-   │└─┘    │a│◀──────────┼─│✓ MATCH│       
-   └─▲─────┴─┴───────────┘ └───────┘       
-     │    ┌───────┐                        
-     └────│✓ MATCH│                        
-          └───────┘                        
-                                           
-                                           
+          ┌────────┐
+   ┌──────┤fragment├─────┐
+   │      └──────┬─┤     │ ┌───────┐
+   │             │a│◀────┼─│✓ MATCH│
+   │          ┌─┐└─┘     │ └───────┘
+   │┌─┐       │p│        │
+   ││a│    ┌─┐└─┘        │ ┌───────┐
+   │└─┘    │a│◀──────────┼─│✓ MATCH│
+   └─▲─────┴─┴───────────┘ └───────┘
+     │    ┌───────┐
+     └────│✓ MATCH│
+          └───────┘
+
+
    *Column bounded proximity*
-   `withinColumns = 3`                    
-          ┌────────┐                       
-   ┌────┬─┤fragment├─┬───┐                 
-   │      └──────┬─┤     │ ┌───────────┐   
-   │    │        │a│◀┼───┼─│+1C ✓ MATCH│   
-   │          ┌─┐└─┘     │ └───────────┘   
-   │┌─┐ │     │p│    │   │                 
-┌──▶│a│  ┌─┐  └─┘        │ ┌───────────┐   
-│  │└─┘ ││a│◀────────┼───┼─│-2C ✓ MATCH│   
-│  │       ┘             │ └───────────┘   
-│  └── -3C ───0C─── +3C ─┘                 
-│  ┌─────────┐                             
-│  │ -4C ✗ NO│                             
-└──│  MATCH  │                             
-   └─────────┘                             
-                                           
-                                           
+   `withinColumns = 3`
+          ┌────────┐
+   ┌────┬─┤fragment├─┬───┐
+   │      └──────┬─┤     │ ┌───────────┐
+   │    │        │a│◀┼───┼─│+1C ✓ MATCH│
+   │          ┌─┐└─┘     │ └───────────┘
+   │┌─┐ │     │p│    │   │
+┌──▶│a│  ┌─┐  └─┘        │ ┌───────────┐
+│  │└─┘ ││a│◀────────┼───┼─│-2C ✓ MATCH│
+│  │       ┘             │ └───────────┘
+│  └── -3C ───0C─── +3C ─┘
+│  ┌─────────┐
+│  │ -4C ✗ NO│
+└──│  MATCH  │
+   └─────────┘
+
+
    *Line bounded proximity*
-   `withinLines = 4`                      
-         ┌────────┐                        
-   ┌─────┤fragment├─────┐                  
-  +4L─ ─ ┴────────┘─ ─ ─│                  
-   │                    │                  
-   │              ┌─┐   │ ┌────────────┐   
-   │         ┌─┐  │a│◀──┼─│+1L ✓ MATCH │   
-   0L  ┌─┐   │p│  └─┘   │ ├────────────┤   
-   │   │a│◀──┴─┴────────┼─│-1L ✓ MATCH │   
-   │   └─┘              │ └────────────┘   
-   │                    │ ┌─────────┐      
-  -4L─ ─ ─ ─ ─ ─ ─ ─┌─┐─│ │-5L ✗ NO │      
-   │                │a│◀┼─│  MATCH  │      
-   └────────────────┴─┴─┘ └─────────┘      
-                                           
-                                           
+   `withinLines = 4`
+         ┌────────┐
+   ┌─────┤fragment├─────┐
+  +4L─ ─ ┴────────┘─ ─ ─│
+   │                    │
+   │              ┌─┐   │ ┌────────────┐
+   │         ┌─┐  │a│◀──┼─│+1L ✓ MATCH │
+   0L  ┌─┐   │p│  └─┘   │ ├────────────┤
+   │   │a│◀──┴─┴────────┼─│-1L ✓ MATCH │
+   │   └─┘              │ └────────────┘
+   │                    │ ┌─────────┐
+  -4L─ ─ ─ ─ ─ ─ ─ ─┌─┐─│ │-5L ✗ NO │
+   │                │a│◀┼─│  MATCH  │
+   └────────────────┴─┴─┘ └─────────┘
+
+
    *Line and column bounded proximity*
-   `withinLines = 4`                      
-   `withinColumns = 3`                    
-         ┌────────┐                        
-   ┌─────┤fragment├─────┐                  
-  +4L   ┌└────────┴ ┐   │                  
+   `withinLines = 4`
+   `withinColumns = 3`
+         ┌────────┐
+   ┌─────┤fragment├─────┐
+  +4L   ┌└────────┴ ┐   │
    │            ┌─┐     │ ┌───────────────┐
    │    │       │a│◀┼───┼─│+2L/+1C ✓ MATCH│
    │         ┌─┐└─┘     │ └───────────────┘
-   0L   │    │p│    │   │                  
-   │         └─┘        │                  
-   │    │           │   │ ┌────────────┐   
-  -4L    ─ ─ ─ ─ ─ ─┌─┐ │ │-5L/+3C ✗ NO│   
-   │                │a│◀┼─│   MATCH    │   
-   └───-3C────0L───+3C┴─┘ └────────────┘   
+   0L   │    │p│    │   │
+   │         └─┘        │
+   │    │           │   │ ┌────────────┐
+  -4L    ─ ─ ─ ─ ─ ─┌─┐ │ │-5L/+3C ✗ NO│
+   │                │a│◀┼─│   MATCH    │
+   └───-3C────0L───+3C┴─┘ └────────────┘
 ```
 
 <details><summary>Some final quick thoughts on composite rules.</summary>This is an experimental feature! It's subject to change so don't go sellin' a new B2B SaaS feature built ontop of this feature. Scan type (git vs dir) based context is interesting. I'm monitoring the situation. Composite rules might not be super useful for git scans because gitleaks only looks at additions in the git history. It could be useful to scan non-additions in git history for `required` rules. Oh, right this is a readme, I'll shut up now.</details>
-  
+
 #### gitleaks:allow
 
 If you are knowingly committing a test secret that gitleaks will catch you can add a `gitleaks:allow` comment to that line which will instruct gitleaks

--- a/cmd/directory.go
+++ b/cmd/directory.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -56,7 +55,7 @@ func runDirectory(cmd *cobra.Command, args []string) {
 	}
 
 	findings, err := detector.DetectSource(
-		context.Background(),
+		cmd.Context(),
 		&sources.Files{
 			Config:          &cfg,
 			FollowSymlinks:  detector.FollowSymlinks,

--- a/cmd/generate/config/rules/notion.go
+++ b/cmd/generate/config/rules/notion.go
@@ -6,34 +6,34 @@ import (
 )
 
 func Notion() *config.Rule {
-    // Define the identifiers that match the Keywords
-    identifiers := []string{"ntn_"}
-    
-    // Define the regex pattern for Notion API token
-    secretRegex := `ntn_[0-9]{11}[A-Za-z0-9]{32}[A-Za-z0-9]{3}`
-    
-    regex := utils.GenerateUniqueTokenRegex(secretRegex, false)
-    
-    r := config.Rule{
-        Description: "Notion API token",
-        RuleID: "notion-api-token",
-        Regex: regex,
-        Entropy: 4,
-        Keywords: identifiers,
-    }
+	// Define the identifiers that match the Keywords
+	identifiers := []string{"ntn_"}
 
-    // validate
+	// Define the regex pattern for Notion API token
+	secretRegex := `ntn_[0-9]{11}[A-Za-z0-9]{32}[A-Za-z0-9]{3}`
+
+	regex := utils.GenerateUniqueTokenRegex(secretRegex, false)
+
+	r := config.Rule{
+		Description: "Notion API token",
+		RuleID:      "notion-api-token",
+		Regex:       regex,
+		Entropy:     4,
+		Keywords:    identifiers,
+	}
+
+	// validate
 	tps := []string{
 		"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",
 		"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",
 		"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",
 	}
 
-	fps:= []string{
+	fps := []string{
 		"ntn_12345678901",
 		"ntn_123456789012345678901234567890123456789012345678901234567890",
 		"ntn_12345678901abc",
 	}
 
-    return utils.Validate(r, tps, fps)
+	return utils.Validate(r, tps, fps)
 }

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -63,13 +62,13 @@ func runGit(cmd *cobra.Command, args []string) {
 	)
 
 	if preCommit || staged {
-		if gitCmd, err = sources.NewGitDiffCmd(source, staged); err != nil {
+		if gitCmd, err = sources.NewGitDiffCmdContext(cmd.Context(), source, staged); err != nil {
 			logging.Fatal().Err(err).Msg("could not create Git diff cmd")
 		}
 		// Remote info + links are irrelevant for staged changes.
 		scmPlatform = scm.NoPlatform
 	} else {
-		if gitCmd, err = sources.NewGitLogCmd(source, logOpts); err != nil {
+		if gitCmd, err = sources.NewGitLogCmdContext(cmd.Context(), source, logOpts); err != nil {
 			logging.Fatal().Err(err).Msg("could not create Git log cmd")
 		}
 		if scmPlatform, err = scm.PlatformFromString(mustGetStringFlag(cmd, "platform")); err != nil {
@@ -78,11 +77,11 @@ func runGit(cmd *cobra.Command, args []string) {
 	}
 
 	findings, err = detector.DetectSource(
-		context.Background(),
+		cmd.Context(),
 		&sources.Git{
 			Cmd:             gitCmd,
 			Config:          &detector.Config,
-			Remote:          sources.NewRemoteInfo(scmPlatform, source),
+			Remote:          sources.NewRemoteInfoContext(cmd.Context(), scmPlatform, source),
 			Sema:            detector.Sema,
 			MaxArchiveDepth: detector.MaxArchiveDepth,
 		},

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -53,7 +53,7 @@ func runProtect(cmd *cobra.Command, args []string) {
 		remote *detect.RemoteInfo
 	)
 
-	if gitCmd, err = sources.NewGitDiffCmd(source, staged); err != nil {
+	if gitCmd, err = sources.NewGitDiffCmdContext(cmd.Context(), source, staged); err != nil {
 		logging.Fatal().Err(err).Msg("could not create Git diff cmd")
 	}
 	remote = &detect.RemoteInfo{Platform: scm.NoPlatform}

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"os"
 	"time"
 
@@ -38,7 +37,7 @@ func runStdIn(cmd *cobra.Command, _ []string) {
 	exitCode := mustGetIntFlag(cmd, "exit-code")
 
 	findings, err := detector.DetectSource(
-		context.Background(),
+		cmd.Context(),
 		&sources.File{
 			Content:         os.Stdin,
 			MaxArchiveDepth: detector.MaxArchiveDepth,

--- a/sources/git.go
+++ b/sources/git.go
@@ -63,6 +63,12 @@ func (br *blobReader) Close() error {
 // Caller should read everything from channels until receiving a signal about their closure and call
 // the `func (*DiffFilesCmd) Wait()` error in order to release resources.
 func NewGitLogCmd(source string, logOpts string) (*GitCmd, error) {
+	return NewGitLogCmdContext(context.Background(), source, logOpts)
+}
+
+// NewGitLogCmdContext is the same as NewGitLogCmd but supports passing in a
+// context to use for timeouts
+func NewGitLogCmdContext(ctx context.Context, source string, logOpts string) (*GitCmd, error) {
 	sourceClean := filepath.Clean(source)
 	var cmd *exec.Cmd
 	if logOpts != "" {
@@ -82,9 +88,9 @@ func NewGitLogCmd(source string, logOpts string) (*GitCmd, error) {
 		}
 
 		args = append(args, userArgs...)
-		cmd = exec.Command("git", args...)
+		cmd = exec.CommandContext(ctx, "git", args...)
 	} else {
-		cmd = exec.Command("git", "-C", sourceClean, "log", "-p", "-U0",
+		cmd = exec.CommandContext(ctx, "git", "-C", sourceClean, "log", "-p", "-U0",
 			"--full-history", "--all", "--diff-filter=tuxdb")
 	}
 
@@ -122,11 +128,17 @@ func NewGitLogCmd(source string, logOpts string) (*GitCmd, error) {
 // Caller should read everything from channels until receiving a signal about their closure and call
 // the `func (*DiffFilesCmd) Wait()` error in order to release resources.
 func NewGitDiffCmd(source string, staged bool) (*GitCmd, error) {
+	return NewGitDiffCmdContext(context.Background(), source, staged)
+}
+
+// NewGitDiffCmdContext is the same as NewGitDiffCmd but supports passing in a
+// context to use for timeouts
+func NewGitDiffCmdContext(ctx context.Context, source string, staged bool) (*GitCmd, error) {
 	sourceClean := filepath.Clean(source)
 	var cmd *exec.Cmd
-	cmd = exec.Command("git", "-C", sourceClean, "diff", "-U0", "--no-ext-diff", ".")
+	cmd = exec.CommandContext(ctx, "git", "-C", sourceClean, "diff", "-U0", "--no-ext-diff", ".")
 	if staged {
-		cmd = exec.Command("git", "-C", sourceClean, "diff", "-U0", "--no-ext-diff",
+		cmd = exec.CommandContext(ctx, "git", "-C", sourceClean, "diff", "-U0", "--no-ext-diff",
 			"--staged", ".")
 	}
 	logging.Debug().Msgf("executing: %s", cmd.String())
@@ -177,13 +189,24 @@ func (c *GitCmd) Wait() error {
 	return c.cmd.Wait()
 }
 
+// String displays the command used for GitCmd
+func (c *GitCmd) String() string {
+	return c.cmd.String()
+}
+
 // NewBlobReader returns an io.ReadCloser that can be used to read a blob
 // within the git repo used to create the GitCmd.
 //
 // The caller is responsible for closing the reader.
 func (c *GitCmd) NewBlobReader(commit, path string) (io.ReadCloser, error) {
+	return c.NewBlobReaderContext(context.Background(), commit, path)
+}
+
+// NewBlobReaderContext is the same as NewBlobReader but supports passing in a
+// context to use for timeouts
+func (c *GitCmd) NewBlobReaderContext(ctx context.Context, commit, path string) (io.ReadCloser, error) {
 	gitArgs := []string{"-C", c.repoPath, "cat-file", "blob", commit + ":" + path}
-	cmd := exec.Command("git", gitArgs...)
+	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Stderr = io.Discard
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -275,7 +298,9 @@ type CommitInfo struct {
 // Fragments yields fragments from a git repo
 func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 	defer func() {
-		_ = s.Cmd.Wait()
+		if err := s.Cmd.Wait(); err != nil {
+			logging.Debug().Err(err).Str("cmd", s.Cmd.String()).Msg("command aborted")
+		}
 	}()
 
 	var (
@@ -287,6 +312,8 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 	// loop to range over both DiffFiles (stdout) and ErrCh (stderr)
 	for diffFilesCh != nil || errCh != nil {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case gitdiffFile, open := <-diffFilesCh:
 			if !open {
 				diffFilesCh = nil
@@ -336,7 +363,7 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 				defer wg.Done()
 
 				if yieldAsArchive {
-					blob, err := s.Cmd.NewBlobReader(commitSHA, gitdiffFile.NewName)
+					blob, err := s.Cmd.NewBlobReaderContext(ctx, commitSHA, gitdiffFile.NewName)
 					if err != nil {
 						logging.Error().Err(err).Msg("could not read archive blob")
 						return nil
@@ -394,17 +421,28 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 		}
 	}
 
-	wg.Wait()
-	return nil
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		wg.Wait()
+		return nil
+	}
 }
 
 // NewRemoteInfo builds a new RemoteInfo for generating finding links
 func NewRemoteInfo(platform scm.Platform, source string) *RemoteInfo {
+	return NewRemoteInfoContext(context.Background(), platform, source)
+}
+
+// NewRemoteInfoContext is the same as NewRemoteInfo but supports passing in a
+// context to use for timeouts
+func NewRemoteInfoContext(ctx context.Context, platform scm.Platform, source string) *RemoteInfo {
 	if platform == scm.NoPlatform {
 		return &RemoteInfo{Platform: platform}
 	}
 
-	remoteUrl, err := getRemoteUrl(source)
+	remoteUrl, err := getRemoteUrl(ctx, source)
 	if err != nil {
 		if strings.Contains(err.Error(), "No remote configured") {
 			logging.Debug().Msg("skipping finding links: repository has no configured remote.")
@@ -442,9 +480,9 @@ End:
 
 var sshUrlpat = regexp.MustCompile(`^git@([a-zA-Z0-9.-]+):(?:\d{1,5}/)?([\w/.-]+?)(?:\.git)?$`)
 
-func getRemoteUrl(source string) (*url.URL, error) {
+func getRemoteUrl(ctx context.Context, source string) (*url.URL, error) {
 	// This will return the first remote — typically, "origin".
-	cmd := exec.Command("git", "ls-remote", "--quiet", "--get-url")
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--quiet", "--get-url")
 	if source != "." {
 		cmd.Dir = source
 	}


### PR DESCRIPTION
### Description:

Today contexts with timeouts set aren't fully respected, this is adding some support for that so it's easier to bail out during larger scans.

Also I ran `make format` and it touched up a few other places.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
