### PR TITLE
Fixed k8s secrets detection when kube yml have multiple secrets

### DIFF
--- a/cmd/generate/config/rules/kubernetes.go
+++ b/cmd/generate/config/rules/kubernetes.go
@@ -17,7 +17,7 @@ func KubernetesSecret() *config.Rule {
 	// - valid base64 characters
 	// - longer than 10 characters (no "YmFyCg==")
 	//language=regexp
-	dataPat := `\bdata:(?s:.){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))`
+	dataPat := `\bdata:(?s:.){0,100}?\s+((?:[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|'')\s*)+)`
 
 	// define rule
 	r := config.Rule{
@@ -130,6 +130,15 @@ metadata:
   name: secret-dockercfg
 type: kubernetes.io/dockercfg
 kind: Secret`,
+		"before-multiple-secerts.yaml": `apiVersion: v1
+data:
+  ca.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tXG5BMTBCMjBzdXBlcnNlY3JldHBlbWRhdGFcbi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS1cbg==
+  cert.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tXG5DMzBENDBzdXBlcnNlY3JldHBlbWRhdGFcbi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS1cbg==
+  key.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tXG5FNTBGNjBzdXBlcnNlY3JldHBlbWRhdGFcbi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+kind: Secret
+metadata:
+  name: client-certs
+`,
 		// Sample Kubernetes Secret from https://kubernetes.io/docs/concepts/configuration/secret/
 		// The "data"-key is after the identifier "kind: Secret"
 		"after-kubernetes.yaml": `apiVersion: v1
@@ -195,6 +204,15 @@ type: kubernetes.io/dockercfg
 data:
   .dockercfg: >
     eyJhdXRocyI6eyJodHRwczovL2V4YW1wbGUvdjEvIjp7ImF1dGgiOiJvcGVuc2VzYW1lIn19fQo=`,
+		"after-multiple-secerts.yaml": `apiVersion: v1
+kind: Secret
+data:
+  ca.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tXG5BMTBCMjBzdXBlcnNlY3JldHBlbWRhdGFcbi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS1cbg==
+  cert.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tXG5DMzBENDBzdXBlcnNlY3JldHBlbWRhdGFcbi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS1cbg==
+  key.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tXG5FNTBGNjBzdXBlcnNlY3JldHBlbWRhdGFcbi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0=
+metadata:
+  name: client-certs
+`,
 	}
 	fps := map[string]string{
 		"empty-quotes1.yml": `apiVersion: v1            

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2432,7 +2432,7 @@ keywords = ["kraken"]
 [[rules]]
 id = "kubernetes-secret-yaml"
 description = "Possible Kubernetes Secret detected, posing a risk of leaking credentials/tokens from your deployments"
-regex = '''(?i)(?:\bkind:[ \t]*["']?\bsecret\b["']?(?s:.){0,200}?\bdata:(?s:.){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))|\bdata:(?s:.){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))(?s:.){0,200}?\bkind:[ \t]*["']?\bsecret\b["']?)'''
+regex = '''(?i)(?:\bkind:[ \t]*["']?\bsecret\b["']?(?s:.){0,200}?\bdata:(?s:.){0,100}?\s+((?:[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|'')\s*)+)|\bdata:(?s:.){0,100}?\s+((?:[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|'')\s*)+)(?s:.){0,200}?\bkind:[ \t]*["']?\bsecret\b["']?)'''
 path = '''(?i)\.ya?ml$'''
 keywords = ["secret"]
 [[rules.allowlists]]


### PR DESCRIPTION
### Description:
Fixed K8s secerts detection when `kube.yml` have multiple secerts under `data:` #1933

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
