### PR TITLE
Update go to 1.24.9 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zricethezav/gitleaks/v8
 
-go 1.23.8
+go 1.24.9
 
 require (
 	github.com/BobuSumisu/aho-corasick v1.0.3


### PR DESCRIPTION
### Description:
This helps address CVE-2025-47906 and CVE-2025-22874

`make test` shows all tests passing

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
