### PR TITLE
feat: add Django insecure keys detection

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -75,6 +75,7 @@ func main() {
 		rules.DiscordAPIToken(),
 		rules.DiscordClientID(),
 		rules.DiscordClientSecret(),
+		rules.DjangoInsecureSecret(),
 		rules.Doppler(),
 		rules.DropBoxAPISecret(),
 		rules.DropBoxLongLivedAPIToken(),

--- a/cmd/generate/config/rules/django.go
+++ b/cmd/generate/config/rules/django.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+func DjangoInsecureSecret() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "django-insecure-secret-key",
+		Description: "Detected a Django insecure secret key, potentially compromising Django’s security protections against privilege escalation and remote code execution.",
+		Regex:       regexp.MustCompile(`["'](django-insecure-[^"']{1,250})["']`),
+		Path:        regexp.MustCompile(`(?i)\.py$`),
+		SecretGroup: 1,
+		Keywords:    []string{"django-insecure-"},
+	}
+
+	// validate
+	tps := map[string]string{
+		"setting.py": `SECRET_KEY = "django-insecure-123456789!%_&*^)abcdef"`,
+	}
+
+	return utils.ValidateWithPaths(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -438,6 +438,14 @@ entropy = 2
 keywords = ["discord"]
 
 [[rules]]
+id = "django-insecure-secret-key"
+description = "Detected a Django insecure secret key, potentially compromising Django’s security protections against privilege escalation and remote code execution."
+regex = '''["'](django-insecure-[^"']{1,250})["']'''
+path = '''(?i)\.py$'''
+secretGroup = 1
+keywords = ["django-insecure-"]
+
+[[rules]]
 id = "doppler-api-token"
 description = "Discovered a Doppler API token, posing a risk to environment and secrets management security."
 regex = '''dp\.pt\.(?i)[a-z0-9]{43}'''


### PR DESCRIPTION
### Description:
Detects insecure keys generated automatically by Django, see:
- `security.W009` from https://docs.djangoproject.com/en/6.0/ref/checks/#security
- [related Django constant](https://github.com/django/django/blob/7b32485ee98edf7e8b94ad9c8acdccee562bf216/django/core/checks/security/base.py#L21)
- [related Djando code](https://github.com/django/django/blob/7b32485ee98edf7e8b94ad9c8acdccee562bf216/django/core/management/commands/startproject.py#L18) that generates insecure keys

They usually reside in `setting.py` and look like this:
```python
SECRET_KEY = "django-insecure-123456789!%_&*^)abcdef"
```

I've tested a positive case on a local repository, the (redacted) report looks like this:
```json
[
 {
  "RuleID": "django-secret-key",
  "Description": "Detected a Django secret key, potentially compromising many of Django’s security protections against privilege escalation and remote code execution.",
  "StartLine": 23,
  "EndLine": 23,
  "StartColumn": 15,
  "EndColumn": 82,
  "Match": "'django-insecure-REDACTED'",
  "Secret": "django-insecure-REDACTED",
  "File": "config/settings.py",
  "SymlinkFile": "",
  "Commit": "REDACTED",
  "Link": "https://github.com/REDACTED/REDACTED/blob/REDACTED/config/settings.py#L23",
  "Entropy": 5.0895524,
  "Author": "REDACTED",
  "Email": "REDACTED",
  "Date": "REDACTED",
  "Message": "REDACTED",
  "Tags": [],
  "Fingerprint": "REDACTED:config/settings.py:django-secret-key:23"
 }
]
```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
