### PR TITLE
Add maxTargetMegaBytes to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ Gitleaks offers a configuration format you can follow to write your own secret d
 # Title for the gitleaks configuration file.
 title = "Custom Gitleaks configuration"
 
+# (Optional) Maximum file size in megabytes to scan. Files larger than this are skipped.
+# This can be overridden with the --max-target-megabytes command line flag.
+# maxTargetMegaBytes = 100
+
 # You have basically two options for your custom configuration:
 #
 # 1. define your own configuration, default rules do not apply

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -289,8 +289,15 @@ func Detector(cmd *cobra.Command, cfg config.Config, source string) *detect.Dete
 	if detector.Redact, err = cmd.Flags().GetUint("redact"); err != nil {
 		logging.Fatal().Err(err).Send()
 	}
-	if detector.MaxTargetMegaBytes, err = cmd.Flags().GetInt("max-target-megabytes"); err != nil {
+	// Get max target megabytes from flag first, then config if flag is not set
+	maxTargetMegaBytes, err := cmd.Flags().GetInt("max-target-megabytes")
+	if err != nil {
 		logging.Fatal().Err(err).Send()
+	}
+	if maxTargetMegaBytes > 0 {
+		detector.MaxTargetMegaBytes = maxTargetMegaBytes
+	} else if cfg.MaxTargetMegaBytes > 0 {
+		detector.MaxTargetMegaBytes = cfg.MaxTargetMegaBytes
 	}
 	// set ignore gitleaks:allow flag
 	if detector.IgnoreGitleaksAllow, err = cmd.Flags().GetBool("ignore-gitleaks-allow"); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,8 @@ type ViperConfig struct {
 
 	MinVersion string
 
+	MaxTargetMegaBytes int
+
 	configPath string
 }
 
@@ -92,9 +94,10 @@ type Config struct {
 	Rules       map[string]Rule
 	Keywords    map[string]struct{}
 	// used to keep sarif results consistent
-	OrderedRules []string
-	Allowlists   []*Allowlist
-	MinVersion   string
+	OrderedRules       []string
+	Allowlists         []*Allowlist
+	MinVersion         string
+	MaxTargetMegaBytes int
 }
 
 // Extend is a struct that allows users to define how they want their
@@ -195,13 +198,14 @@ func (vc *ViperConfig) Translate() (Config, error) {
 
 	// Assemble the config.
 	c := Config{
-		Title:        vc.Title,
-		Description:  vc.Description,
-		Extend:       vc.Extend,
-		Rules:        rulesMap,
-		Keywords:     keywords,
-		OrderedRules: orderedRules,
-		MinVersion:   vc.MinVersion,
+		Title:              vc.Title,
+		Description:        vc.Description,
+		Extend:             vc.Extend,
+		Rules:              rulesMap,
+		Keywords:           keywords,
+		OrderedRules:       orderedRules,
+		MinVersion:         vc.MinVersion,
+		MaxTargetMegaBytes: vc.MaxTargetMegaBytes,
 	}
 
 	if extendDepth > 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -88,6 +88,19 @@ func TestTranslate(t *testing.T) {
 				}},
 			},
 		},
+		{
+			cfgName: "valid/max_target_megabytes",
+			cfg: Config{
+				Title:             "config with max target megabytes",
+				MaxTargetMegaBytes: 100,
+				Rules: map[string]Rule{"test-rule": {
+					RuleID:   "test-rule",
+					Regex:    regexp.MustCompile(`test`),
+					Keywords: []string{},
+					Tags:     []string{},
+				}},
+			},
+		},
 
 		// Invalid
 		{
@@ -619,6 +632,9 @@ func testTranslate(t *testing.T, test translateCase) {
 		cmpopts.IgnoreUnexported(Rule{}, Allowlist{}),
 	}
 	if diff := cmp.Diff(test.cfg.Title, cfg.Title); diff != "" {
+		t.Errorf("%s diff: (-want +got)\n%s", test.cfgName, diff)
+	}
+	if diff := cmp.Diff(test.cfg.MaxTargetMegaBytes, cfg.MaxTargetMegaBytes); diff != "" {
 		t.Errorf("%s diff: (-want +got)\n%s", test.cfgName, diff)
 	}
 	if diff := cmp.Diff(test.cfg.Rules, cfg.Rules, opts); diff != "" {

--- a/test-config.toml
+++ b/test-config.toml
@@ -1,0 +1,7 @@
+title = "Test config with maxTargetMegaBytes"
+maxTargetMegaBytes = 1
+
+[[rules]]
+id = "generic-api-key"
+description = "Generic API Key"
+regex = '''(?i)(?:key|api|token|secret)'''

--- a/testdata/config/valid/max_target_megabytes.toml
+++ b/testdata/config/valid/max_target_megabytes.toml
@@ -1,0 +1,6 @@
+title = "config with max target megabytes"
+maxTargetMegaBytes = 100
+
+[[rules]]
+id = "test-rule"
+regex = '''test'''


### PR DESCRIPTION
### Description:
This allows configuring a default value for `maxTargetMegaBytes` that can be overridden by the `--max-target-megabytes` flag on the command line. My idea was to avoid having to set this on the command line every time, when I never want it to scan huge files because it takes forever.

> [!NOTE]
> I don't love the config name, I'd be open to changing it. I copied the internal variable name rather than introduce a deviation, but I think it's a bit of an unintuitive name with the capital `B` in `MegaBytes` when the command like uses a single word `megabytes`. I also don't feel strongly here, so fine to keep it.)

### Checklist:

* [X] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
