### PR TITLE
fix: Decoding skips values with Unicode characters

### DIFF
--- a/detect/codec/ascii.go
+++ b/detect/codec/ascii.go
@@ -1,5 +1,7 @@
 package codec
 
+import "unicode/utf8"
+
 var printableASCII [256]bool
 
 func init() {
@@ -10,12 +12,24 @@ func init() {
 	}
 }
 
-// isPrintableASCII returns true if all bytes are printable ASCII
+// isPrintableASCII returns true if all bytes are printable ASCII or valid UTF-8
 func isPrintableASCII(b []byte) bool {
-	for _, c := range b {
-		if !printableASCII[c] {
-			return false
+	for i := 0; i < len(b); {
+		c := b[i]
+		// Check for printable ASCII (single byte)
+		if printableASCII[c] {
+			i++
+			continue
 		}
+		// Check for valid UTF-8 multi-byte sequence
+		if c >= 0x80 {
+			r, size := utf8.DecodeRune(b[i:])
+			if r != utf8.RuneError && size > 1 {
+				i += size
+				continue
+			}
+		}
+		return false
 	}
 
 	return true

--- a/detect/codec/ascii_test.go
+++ b/detect/codec/ascii_test.go
@@ -1,0 +1,78 @@
+package codec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPrintableASCII(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected bool
+	}{
+		{
+			name:     "printable ASCII",
+			input:    []byte("hello world"),
+			expected: true,
+		},
+		{
+			name:     "printable ASCII with tab",
+			input:    []byte("hello\tworld"),
+			expected: true,
+		},
+		{
+			name:     "printable ASCII with newline",
+			input:    []byte("hello\nworld"),
+			expected: true,
+		},
+		{
+			name:     "UTF-8 emoji",
+			input:    []byte("🔓"),
+			expected: true,
+		},
+		{
+			name:     "UTF-8 accented chars",
+			input:    []byte("café"),
+			expected: true,
+		},
+		{
+			name:     "mixed ASCII and UTF-8",
+			input:    []byte("password🔓"),
+			expected: true,
+		},
+		{
+			name:     "UTF-8 Chinese characters",
+			input:    []byte("你好世界"),
+			expected: true,
+		},
+		{
+			name:     "empty input",
+			input:    []byte(""),
+			expected: true,
+		},
+		{
+			name:     "invalid UTF-8 sequence",
+			input:    []byte{0x80, 0x81, 0x82},
+			expected: false,
+		},
+		{
+			name:     "null byte",
+			input:    []byte{0x00},
+			expected: false,
+		},
+		{
+			name:     "control character (bell)",
+			input:    []byte{0x07},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isPrintableASCII(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/detect/codec/decoder_test.go
+++ b/detect/codec/decoder_test.go
@@ -106,6 +106,16 @@ func TestDecode(t *testing.T) {
 			chunk:    `secret=\u0068\u0065\u006c\u006c\u006f\u0020\u0077\u006f\u0072\u006c\u0064 6C6F76656C792070656F706C65206F66206561727468`,
 			expected: "secret=hello world lovely people of earth",
 		},
+		{
+			name:     "b64 with UTF-8 content (emoji)",
+			chunk:    `secret=c2VjcmV0LXBhc3N3b3JkLfCflJM=`,
+			expected: "secret=secret-password-🔓",
+		},
+		{
+			name:     "b64 with UTF-8 content (accented chars)",
+			chunk:    `secret=Y2Fmw6ktYXUtbGFpdC1zZWNyZXQ=`,
+			expected: "secret=café-au-lait-secret",
+		},
 	}
 
 	decoder := NewDecoder()


### PR DESCRIPTION
## Summary
This PR fixes #2000

## Changes
- Updated `isPrintableASCII` function in `detect/codec/ascii.go` to accept valid UTF-8 multi-byte sequences in addition to printable ASCII characters
- Added comprehensive unit tests for `isPrintableASCII` function covering ASCII, UTF-8, and edge cases
- Added integration tests for base64 decoding with UTF-8 content (emojis, accented characters)

## Problem
The decoder was rejecting valid UTF-8 multi-byte sequences because `isPrintableASCII` only accepted single-byte ASCII characters. This caused base64-decoded content containing Unicode characters (like emoji 🔓 or accented characters like café) to be skipped during decoding.

## Solution
Modified `isPrintableASCII` to:
1. Accept printable ASCII bytes (unchanged behavior)
2. Accept valid UTF-8 multi-byte sequences using `unicode/utf8.DecodeRune`
3. Reject invalid UTF-8 sequences and control characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)