### PR TITLE
fix: Configuration with empty [[rules]] array fails to load in v8.29.0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,14 @@ func (vc *ViperConfig) Translate() (Config, error) {
 
 	// Validate individual rules.
 	for _, vr := range vc.Rules {
+		// Skip completely empty rule entries (e.g., from an empty [[rules]] in TOML).
+		if vr.ID == "" && vr.Description == "" && vr.Path == "" && vr.Regex == "" &&
+			vr.SecretGroup == 0 && vr.Entropy == 0 && len(vr.Keywords) == 0 &&
+			len(vr.Tags) == 0 && vr.AllowList == nil && len(vr.Allowlists) == 0 &&
+			len(vr.Required) == 0 && !vr.SkipReport {
+			continue
+		}
+
 		var (
 			pathPat  *regexp.Regexp
 			regexPat *regexp.Regexp

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -88,7 +88,6 @@ func TestTranslate(t *testing.T) {
 				}},
 			},
 		},
-
 		// Invalid
 		{
 			cfgName:   "invalid/rule_missing_id",
@@ -669,4 +668,31 @@ func TestExtendedRuleKeywordsAreDowncase(t *testing.T) {
 			require.Truef(t, exists, "The expected keyword %s did not exist as a key of cfg.Keywords", tt.expectedKeywords)
 		})
 	}
+}
+
+func TestTranslateEmptyRules(t *testing.T) {
+	// Reset global state before and after test
+	extendDepth = 0
+	viper.Reset()
+	t.Cleanup(func() {
+		extendDepth = 0
+		viper.Reset()
+	})
+
+	viper.AddConfigPath(configPath)
+	viper.SetConfigName("valid/empty_rules")
+	viper.SetConfigType("toml")
+	err := viper.ReadInConfig()
+	require.NoError(t, err)
+
+	var vc ViperConfig
+	err = viper.Unmarshal(&vc)
+	require.NoError(t, err)
+
+	cfg, err := vc.Translate()
+	require.NoError(t, err, "Empty [[rules]] entry should not cause an error")
+
+	assert.Equal(t, "Custom Gitleaks configuration", cfg.Title)
+	// The config extends the default, so rules should be populated
+	assert.NotEmpty(t, cfg.Rules, "Default rules should be loaded when extending default config")
 }

--- a/testdata/config/valid/empty_rules.toml
+++ b/testdata/config/valid/empty_rules.toml
@@ -1,0 +1,4 @@
+title = "Custom Gitleaks configuration"
+[extend]
+useDefault = true
+[[rules]]


### PR DESCRIPTION
## Summary
This PR fixes #1985

## Changes
- Skip completely empty rule entries during config parsing (e.g., from an empty `[[rules]]` in TOML)
- Add test case to verify empty `[[rules]]` entries are handled correctly without causing errors
- The fix checks if all rule fields are at their zero/default values before processing, allowing users to have empty `[[rules]]` blocks in their configuration files

## Test plan
- [x] Added `TestTranslateEmptyRules` test case
- [x] All existing tests pass
- [x] Verified the test config file `testdata/config/valid/empty_rules.toml` loads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)