### PR TITLE
fix: --version flag returns placeholder text in v8.29.0 instead of actual version number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8
@@ -55,3 +58,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.24 AS build
+ARG VERSION
 WORKDIR /go/src/github.com/zricethezav/gitleaks
 COPY . .
-RUN VERSION=$(git describe --tags --abbrev=0) && \
+RUN if [ -z "$VERSION" ]; then VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "unknown"); fi && \
 CGO_ENABLED=0 go build -o bin/gitleaks -ldflags "-X=github.com/zricethezav/gitleaks/v8/version.Version=${VERSION}"
 
 FROM alpine:3.22


### PR DESCRIPTION
## Summary
This PR fixes #1984

## Changes
- Modified Dockerfile to accept a VERSION build argument and pass it to the Go linker
- Added fallback logic in Dockerfile to use git describe --tags if VERSION arg is not provided
- Updated .github/workflows/release.yml to fetch full git history and tags during checkout
- Pass the release tag (github.ref_name) as VERSION build argument to Docker build

## How it works
When a release is published, the workflow now passes the release tag to the Docker build via the VERSION build argument. This value is then used with -ldflags to set version.Version at compile time, ensuring the --version flag shows the actual version number.