### PR TITLE
Reducing regex searches in fragments.

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -2422,8 +2422,7 @@ let password = 'Summer2024!';`
 
 			f := tc.fragment
 			f.Raw = raw
-
-			actual := d.detectRule(f, raw, rule, []*codec.EncodedSegment{})
+			actual := d.detectRule(f, raw, rule, []*codec.EncodedSegment{}, nil, nil)
 			compare(t, tc.expected, actual)
 		})
 	}
@@ -2582,7 +2581,7 @@ func TestWindowsFileSeparator_RulePath(t *testing.T) {
 	require.NoError(t, err)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual := d.detectRule(test.fragment, test.fragment.Raw, test.rule, []*codec.EncodedSegment{})
+			actual := d.detectRule(test.fragment, test.fragment.Raw, test.rule, []*codec.EncodedSegment{}, nil, nil)
 			compare(t, test.expected, actual)
 		})
 	}
@@ -2766,7 +2765,7 @@ func TestWindowsFileSeparator_RuleAllowlistPaths(t *testing.T) {
 	require.NoError(t, err)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual := d.detectRule(test.fragment, test.fragment.Raw, test.rule, []*codec.EncodedSegment{})
+			actual := d.detectRule(test.fragment, test.fragment.Raw, test.rule, []*codec.EncodedSegment{}, nil, nil)
 			compare(t, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
### Description:
This commit only affects the secret detection in detect.go.

Regex searches are heavy on the CPU. Reducing them makes the detection faster.

Fixes some edge case bugs.

### Changes:
#### 1. Keyword-to-Rules Mapping
- Before: Built a keyword set, then iterated through all rules checking if any keyword matched
- After: Pre-compute a map during detector initialization, directly mapping keywords to their associated rules, resulting in O(1) rule lookup per keyword match instead of O(rules × keywords)
#### 2. Windowed Regex Search
- Before: Regex searched the entire file content for every rule with match found in prefilter
- After: Use Aho-Corasick match positions to create search windows around keyword locations, reducing the regex search from entire files to smaller (dynamic) sizes
#### 3. Precomputed Newline Indices
- Before: newLineRegexp.FindAllStringIndex()] called once per rule
- After: computeNewlineIndices() called once per fragment, reused across all rules
#### 4. Empty Prefilter Handling
- Changed prefilter from value type to pointer (*ahocorasick.Trie)
- Prevents panic when no rules have keywords (empty Trie)
#### 5. Double Regex Searches
- r.Regex.FindAllStringIndex(currentRaw, -1) is called twice in detectRule
- var matches can be reused in the for loop
### Testing
- All existing tests pass with updated signatures
- Verified detection accuracy matches original implementation

### Summary 
Is faster, but also makes the code more complex. 
I can make a commit with only the changes 3. - 5., if wanted.

### Mayor Changes
#### New Type for keyword positions in fragment (2.)
```go
type KeywordMatch struct {
    Keyword  string
    StartPos int
    EndPos   int
}
```
#### New Detector Fields for keyword to rule mapping (1.)
```go
keywordToRules       map[string][]*config.Rule
rulesWithoutKeywords []*config.Rule
```
#### Updated Function Signatures
```go
func (d *Detector) detectRule(fragment Fragment, currentRaw string, r config.Rule, encodedSegments []*codec.EncodedSegment, newlineIndices [][]int, keywordMatches []KeywordMatch) []report.Finding
```
#### Constants for dynamic window sizing (2.)
```go
const (
    baseWindowSize   = 100  // Minimum chars before/after keyword
    windowMultiplier = 50   // Scale factor for keyword length
)
```

