### PR TITLE
fix RequiredRules and SkipReport not properly applied when extending configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -472,9 +472,13 @@ func (c *Config) extend(extensionConfig Config) {
 			if currentRule.Path != nil {
 				baseRule.Path = currentRule.Path
 			}
+			if currentRule.SkipReport {
+				baseRule.SkipReport = currentRule.SkipReport
+			}
 			baseRule.Tags = append(baseRule.Tags, currentRule.Tags...)
 			baseRule.Keywords = append(baseRule.Keywords, currentRule.Keywords...)
 			baseRule.Allowlists = append(baseRule.Allowlists, currentRule.Allowlists...)
+			baseRule.RequiredRules = append(baseRule.RequiredRules, currentRule.RequiredRules...)
 			// The keywords from the base rule and the extended rule must be merged into the global keywords list
 			for _, k := range baseRule.Keywords {
 				c.Keywords[k] = struct{}{}


### PR DESCRIPTION
### Description:
When extending a configuration (using `useDefault = true` or otherwise) the `RequiredRules` and `SkipReport` fields were not being merged into the base configuration.

This had the unwanted side effect of omitting these settings entirely, making the `RequiredRules` mechanism fail completely if the base configuration was being extended.

The fix is pretty simple.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

Sorry, I really don't want to bother with tests rn...