### PR TITLE
fix: stop passing filenames for gitleaks-system

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,3 +15,4 @@
   description: Detect hardcoded secrets using Gitleaks
   entry: gitleaks git --pre-commit --redact --staged --verbose
   language: system
+  pass_filenames: false


### PR DESCRIPTION
The missing `pass_filenames: false` causes the `gitleaks-system` hook to fail.

#1850 fixed the same issue for the `gitleaks-docker` hook.

### Description:
Explain the purpose of the PR.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
