### PR TITLE
feat: add OpenRouter API key detection

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -177,6 +177,7 @@ func main() {
 		rules.OctopusDeployApiKey(),
 		rules.OktaAccessToken(),
 		rules.OpenAI(),
+		rules.OpenRouterApiKey(),
 		rules.OpenshiftUserToken(),
 		rules.PerplexityAPIKey(),
 		rules.PlaidAccessID(),

--- a/cmd/generate/config/rules/openrouter.go
+++ b/cmd/generate/config/rules/openrouter.go
@@ -1,0 +1,40 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func OpenRouterApiKey() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "openrouter-api-key",
+		Description: "Detected an OpenRouter API Key, posing a risk of unauthorized access to AI models and budget consumption.",
+		Regex:       utils.GenerateUniqueTokenRegex(`sk-or(-v\d+)?-[a-f0-9]{64}`, false),
+		Keywords: []string{
+			"sk-or",
+		},
+	}
+
+	// validate
+	tps := []string{
+		// Valid API key examples
+		"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",
+		"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",
+		"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",
+		// Generate additional random test keys
+		utils.GenerateSampleSecret("openrouter", "sk-or-v1-"+secrets.NewSecret(utils.Hex("64"))),
+	}
+
+	fps := []string{
+		// Too short key (missing characters)
+		"sk-or-v1-faae9eb62e12ed4c6a3680ac0805d49cfb8f6a0c91bf405abd1c32f5e7c0916",
+		// Wrong suffix
+		"sk-ant-v1-faae9eb62e12ed4c6a3680ac0805d49cfb8f6a0c91bf405abd1c32f5e7c0916f",
+		// Non-hexadecimal characters (contains 'g')
+		"sk-or-v1-gaae9eb62e12ed4c6a3680ac0805d49cfb8f6a0c91bf405abd1c32f5e7c0916f",
+	}
+
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2708,6 +2708,12 @@ entropy = 3
 keywords = ["t3blbkfj"]
 
 [[rules]]
+id = "openrouter-api-key"
+description = "Detected an OpenRouter API Key, posing a risk of unauthorized access to AI models and budget consumption."
+regex = '''\b(sk-or(-v\d+)?-[a-f0-9]{64})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = ["sk-or"]
+
+[[rules]]
 id = "openshift-user-token"
 description = "Found an OpenShift user token, potentially compromising an OpenShift/Kubernetes cluster."
 regex = '''\b(sha256~[\w-]{43})(?:[^\w-]|\z)'''


### PR DESCRIPTION
### Description:

Add detection rule for OpenRouter API key:

- openrouter-api-key: detects sk-or-v... keys

The OpenRouter API keys follow the pattern sk-or-{version}-{64 characters}, and this rule is designed to identify them in order to prevent unauthorized access to the OpenRouter service and ensure that sensitive tokens aren't exposed in version control.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
