### PR TITLE
fix: Add pass_filenames: false to gitleaks-system

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,3 +15,4 @@
   description: Detect hardcoded secrets using Gitleaks
   entry: gitleaks git --pre-commit --redact --staged --verbose
   language: system
+  pass_filenames: false


### PR DESCRIPTION
### Description:
Like in !1749 I'm getting similar messages when using the "id mode" `gitleaks-system`, the PR !1850 fixed it for `gitleaks-docker`, same 

Prevent such error
<img width="667" height="176" alt="image" src="https://github.com/user-attachments/assets/f8a17e8d-219d-4134-9047-e8e4f968f63c" />

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?

