### PR TITLE
feat: add Replicate API token detection rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -194,6 +194,7 @@ func main() {
 		rules.PyPiUploadToken(),
 		rules.RapidAPIAccessToken(),
 		rules.ReadMe(),
+		rules.ReplicateAPIToken(),
 		rules.RubyGemsAPIToken(),
 		rules.ScalingoAPIToken(),
 		rules.SendbirdAccessID(),

--- a/cmd/generate/config/rules/replicate.go
+++ b/cmd/generate/config/rules/replicate.go
@@ -1,0 +1,22 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func ReplicateAPIToken() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "replicate-api-token",
+		Description: "Detected a Replicate API token, risking unauthorized access to AI model endpoints.",
+		Regex:       utils.GenerateUniqueTokenRegex(`r8_[a-zA-Z0-9]{40}`, true),
+		Entropy:     2,
+		Keywords:    []string{"r8_"},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("replicate", "r8_"+secrets.NewSecret(utils.AlphaNumeric("40")))
+	return utils.Validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2826,6 +2826,13 @@ entropy = 2
 keywords = ["rdme_"]
 
 [[rules]]
+id = "replicate-api-token"
+description = "Detected a Replicate API token, risking unauthorized access to AI model endpoints."
+regex = '''(?i)\b(r8_[a-zA-Z0-9]{40})(?:[\x60'"\s;]|\\[nr]|$)'''
+entropy = 2
+keywords = ["r8_"]
+
+[[rules]]
 id = "rubygems-api-token"
 description = "Identified a Rubygem API token, potentially compromising Ruby library distribution and package management."
 regex = '''\b(rubygems_[a-f0-9]{48})(?:[\x60'"\s;]|\\[nr]|$)'''


### PR DESCRIPTION
Adds detection for Replicate API tokens (`r8_` prefix + 40 alphanumeric chars).