### PR TITLE
Fix git errors being incorrectly ignored

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -226,9 +226,9 @@ func (d *Detector) DetectSource(ctx context.Context, source sources.Source) ([]r
 		logger := logContext.Logger()
 
 		if err != nil {
-			// Log the error and move on to the next fragment
+			// Log the error and propagate it to stop the scan
 			logger.Error().Err(err).Send()
-			return nil
+			return err
 		}
 
 		// both the fragment's content and path should be empty for it to be


### PR DESCRIPTION
Fixes #1981. When git errors occur (e.g., not being in a git repo or invalid git options), gitleaks was exiting with code 0 instead of a non-zero exit code. The error was being logged but not propagated, causing the scan to continue. This fix ensures that git errors are properly propagated and result in a non-zero exit code.