### PR TITLE
fix: use [[allowlists]] in generated gitleaks.toml

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -18,7 +18,7 @@ title = "{{.Title}}"
 # config-enabled features are guaranteed to work.
 minVersion = "v8.25.0"
 
-{{ with .Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}# TODO: change to [[allowlists]]{{println}}[allowlist]
+{{ with .Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}[[allowlists]]
 {{- with .Description }}{{println}}description = "{{ . }}"{{ end }}
 {{- with .MatchCondition }}{{println}}condition = "{{ .String }}"{{ end }}
 {{- with .Commits -}}{{println}}commits = [

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -18,8 +18,7 @@ title = "gitleaks config"
 # config-enabled features are guaranteed to work.
 minVersion = "v8.25.0"
 
-# TODO: change to [[allowlists]]
-[allowlist]
+[[allowlists]]
 description = "global allow lists"
 paths = [
     '''gitleaks\.toml''',


### PR DESCRIPTION
### Description:
Fixes #2048

Addressed TODO comment to update template to use [[allowlists]] and regenerated config/gitleaks.toml.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
