### PR TITLE
feat(rules): add detection rules for Groq, xAI, and Supabase tokens

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -101,6 +101,7 @@ func main() {
 		rules.Freemius(),
 		rules.FreshbooksAccessToken(),
 		rules.GoCardless(),
+		rules.GroqAPIKey(),
 		// TODO figure out what makes sense for GCP
 		// rules.GCPServiceAccount(),
 		rules.GCPAPIKey(),
@@ -228,6 +229,7 @@ func main() {
 		rules.StripeAccessToken(),
 		rules.SquareAccessToken(),
 		rules.SquareSpaceAccessToken(),
+		rules.SupabaseServiceKey(),
 		rules.SumoLogicAccessID(),
 		rules.SumoLogicAccessToken(),
 		rules.TeamsWebhook(),
@@ -243,6 +245,7 @@ func main() {
 		rules.Typeform(),
 		rules.VaultBatchToken(),
 		rules.VaultServiceToken(),
+		rules.XAIAPIKey(),
 		rules.YandexAPIKey(),
 		rules.YandexAWSAccessToken(),
 		rules.YandexAccessToken(),

--- a/cmd/generate/config/rules/groq.go
+++ b/cmd/generate/config/rules/groq.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+// https://console.groq.com/docs/openai
+func GroqAPIKey() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "groq-api-key",
+		Description: "Detected a Groq API key, which could allow unauthorized access to Groq AI inference services and incur unexpected costs.",
+		Regex:       utils.GenerateUniqueTokenRegex(`gsk_[a-zA-Z0-9]{48}`, false),
+		Entropy:     4,
+		Keywords:    []string{"gsk_"},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("groq", "gsk_"+secrets.NewSecret(utils.AlphaNumeric("48")))
+	fps := []string{
+		`GSK_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`, // placeholder, not real
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/cmd/generate/config/rules/supabase.go
+++ b/cmd/generate/config/rules/supabase.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+// https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
+func SupabaseServiceKey() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "supabase-service-key",
+		Description: "Detected a Supabase Personal Access Token (PAT), which could allow unauthorized access to Supabase project management APIs.",
+		Regex:       utils.GenerateUniqueTokenRegex(`sbp_[a-f0-9]{40}`, false),
+		Entropy:     3.5,
+		Keywords:    []string{"sbp_"},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("supabase", "sbp_"+secrets.NewSecret(utils.Hex("40")))
+	fps := []string{
+		`SUPABASE_PAT=sbp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`, // placeholder, not real
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/cmd/generate/config/rules/xai.go
+++ b/cmd/generate/config/rules/xai.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+// https://docs.x.ai/docs/overview#getting-started
+func XAIAPIKey() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "xai-api-key",
+		Description: "Detected an xAI API key, which could allow unauthorized access to xAI (Grok) AI services and data exposure.",
+		Regex:       utils.GenerateUniqueTokenRegex(`xai-[A-Za-z0-9]{80}`, false),
+		Entropy:     4,
+		Keywords:    []string{"xai-"},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("xai", "xai-"+secrets.NewSecret(utils.AlphaNumeric("80")))
+	fps := []string{
+		`XAI_API_KEY=xai-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`, // placeholder, not real
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2315,6 +2315,13 @@ entropy = 3
 keywords = ["glsa_"]
 
 [[rules]]
+id = "groq-api-key"
+description = "Detected a Groq API key, which could allow unauthorized access to Groq AI inference services and incur unexpected costs."
+regex = '''\b(gsk_[a-zA-Z0-9]{48})(?:[\x60'"\s;]|\\[nr]|$)'''
+entropy = 4
+keywords = ["gsk_"]
+
+[[rules]]
 id = "harness-api-key"
 description = "Identified a Harness Access Token (PAT or SAT), risking unauthorized access to a Harness account."
 regex = '''(?:pat|sat)\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9]{24}\.[a-zA-Z0-9]{20}'''
@@ -3102,6 +3109,13 @@ entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
+id = "supabase-service-key"
+description = "Detected a Supabase Personal Access Token (PAT), which could allow unauthorized access to Supabase project management APIs."
+regex = '''\b(sbp_[a-f0-9]{40})(?:[\x60'"\s;]|\\[nr]|$)'''
+entropy = 3.5
+keywords = ["sbp_"]
+
+[[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
 regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[\x60'"\s;]|\\[nr]|$)'''
@@ -3182,6 +3196,13 @@ keywords = [
 regexes = [
     '''s\.[A-Za-z]{24}''',
 ]
+
+[[rules]]
+id = "xai-api-key"
+description = "Detected an xAI API key, which could allow unauthorized access to xAI (Grok) AI services and data exposure."
+regex = '''\b(xai-[A-Za-z0-9]{80})(?:[\x60'"\s;]|\\[nr]|$)'''
+entropy = 4
+keywords = ["xai-"]
 
 [[rules]]
 id = "yandex-access-token"


### PR DESCRIPTION
## Description

This PR adds three new secret detection rules for widely-used AI and cloud services that are not yet covered by the default Gitleaks configuration.

### New Rules

| Rule ID | Service | Pattern | Method |
|---------|---------|---------|--------|
| `groq-api-key` | [Groq](https://console.groq.com/docs/openai) | `gsk_[a-zA-Z0-9]{48}` | `GenerateUniqueTokenRegex` |
| `xai-api-key` | [xAI (Grok)](https://docs.x.ai/docs/overview) | `xai-[A-Za-z0-9]{80}` | `GenerateUniqueTokenRegex` |
| `supabase-service-key` | [Supabase PAT](https://supabase.com/docs/guides/getting-started) | `sbp_[a-f0-9]{40}` | `GenerateUniqueTokenRegex` |

### Rationale

- All three prefixes are longer than 3 characters, making `GenerateUniqueTokenRegex` appropriate (low false-positive risk without requiring surrounding context keywords).
- Groq and xAI are rapidly growing LLM API providers; leaked keys can result in significant unauthorized usage costs.
- Supabase Personal Access Tokens (`sbp_` format) grant full project management access via the Management API and are increasingly found in CI/CD configs and dotfiles.

### Checklist

- [x] New Go rule files created under `cmd/generate/config/rules/`
- [x] `cmd/generate/config/main.go` updated (rules added in alphabetical order)
- [x] `config/gitleaks.toml` regenerated via `go generate ./...`
- [x] Project builds successfully (`go build ./...`)
- [x] True positive and false positive test cases included in each rule