### PR TITLE
Add Azure Storage Account Key detection rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -48,6 +48,7 @@ func main() {
 		rules.Authress(),
 		rules.AWS(),
 		rules.AzureActiveDirectoryClientSecret(),
+		rules.AzureStorageAccountKey(),
 		rules.BitBucketClientID(),
 		rules.BitBucketClientSecret(),
 		rules.BittrexAccessKey(),

--- a/cmd/generate/config/rules/azure.go
+++ b/cmd/generate/config/rules/azure.go
@@ -63,3 +63,28 @@ func AzureActiveDirectoryClientSecret() *config.Rule {
 	}
 	return utils.Validate(r, tps, fps)
 }
+
+// References:
+// - https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage
+// - https://github.com/gitleaks/gitleaks/issues/539
+func AzureStorageAccountKey() *config.Rule {
+	// Azure Storage account keys are 512-bit keys, base64-encoded to 86 characters + "==".
+	r := config.Rule{
+		RuleID:      "azure-storage-account-key",
+		Description: "Identified an Azure Storage Account Key, which could lead to unauthorized access to Azure Storage services and data.",
+		Regex: utils.GenerateSemiGenericRegex(
+			[]string{"accountkey", "account_key", "azure_storage", "azurestoragekey", "storage_key"},
+			`[a-zA-Z0-9+/]{86}==`,
+			true,
+		),
+		Keywords: []string{"accountkey", "account_key", "azure_storage", "azurestoragekey", "storage_key"},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("accountkey", secrets.NewSecret(`[a-zA-Z0-9+/]{86}`)+`==`)
+	fps := []string{
+		`AccountKey=dGhpcyBpcyBhIHRlc3Qgc3RyaW5nIHdpdGggbm8gcmVhbCBrZXkgZGF0YSBpbiBpdCBhdCBhbGwu`, // no trailing ==
+		`AccountKey=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==`, // repetitive
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -241,6 +241,18 @@ entropy = 3
 keywords = ["q~"]
 
 [[rules]]
+id = "azure-storage-account-key"
+description = "Identified an Azure Storage Account Key, which could lead to unauthorized access to Azure Storage services and data."
+regex = '''(?i)[\w.-]{0,50}?(?:accountkey|account_key|azure_storage|azurestoragekey|storage_key)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-zA-Z0-9+/]{86}==)(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = [
+    "accountkey",
+    "account_key",
+    "azure_storage",
+    "azurestoragekey",
+    "storage_key",
+]
+
+[[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
 regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}(b_[a-z0-9=_\-]{44})(?:[\x60'"\s;]|\\[nr]|$)'''


### PR DESCRIPTION
## Summary

Adds a new detection rule for Azure Storage Account Keys, addressing part of #539.

Azure Storage account keys are 512-bit base64-encoded strings (86 characters + `==`) that grant full access to a storage account. Leaking these keys allows unauthorized read/write/delete access to blobs, queues, tables, and file shares.

## Implementation

- New rule `azure-storage-account-key` in `cmd/generate/config/rules/azure.go`
- Uses `GenerateSemiGenericRegex` with context keywords (`accountkey`, `account_key`, `azure_storage`, `azurestoragekey`, `storage_key`) to reduce false positives
- Matches the base64 pattern `[a-zA-Z0-9+/]{86}==`
- Registered in `cmd/generate/config/main.go` (alphabetical order)
- TOML config regenerated via `go run`

## References

- [Azure Storage Account Keys documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage)
- [jessehouwing/gitleaks-azure](https://github.com/jessehouwing/gitleaks-azure) — community rules referenced in #539

## Testing

- All existing tests pass (`go test ./...`)
- Rule validated with `utils.GenerateSampleSecrets` true positives across multiple config formats
- False positives verified: strings without trailing `==`, repetitive characters

Fixes part of #539