### PR TITLE
Add default Spring Boot YAML placeholder secret detection rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -226,6 +226,7 @@ func main() {
 		rules.Sonar(),
 		rules.SourceGraph(),
 		rules.StripeAccessToken(),
+		rules.SpringPlaceholderSecret(),		
 		rules.SquareAccessToken(),
 		rules.SquareSpaceAccessToken(),
 		rules.SumoLogicAccessID(),

--- a/cmd/generate/config/rules/spring.go
+++ b/cmd/generate/config/rules/spring.go
@@ -1,0 +1,34 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+// SpringPlaceholderSecret detects Spring Boot property placeholders with hardcoded default secrets in YAML files.
+func SpringPlaceholderSecret() *config.Rule {
+	r := config.Rule{
+		RuleID:      "spring-placeholder-with-secret",
+		Description: "Secret embedded as default value in Spring Boot property placeholders, such as `${VAR:secret}` in YAML files.",
+		Regex:       regexp.MustCompile(`(?i)\$\{[A-Z0-9_]+:([A-Za-z0-9+/=_-]{20,})\}`),
+		SecretGroup: 1,
+		Path:        regexp.MustCompile(`(?i)\.ya?ml$`),
+		Tags:        []string{"secret", "spring", "placeholder", "default-value"},
+	}
+
+	tps := map[string]string{
+		"application.yaml": `openai:
+  api-key: ${OPENAI_API_KEY:gsk_wewew222dfrffdsASRerTwr}`,
+		"application.yml": `openai:
+  api-key: ${OPENAI_API_KEY:gsk_wewew222dfrffdsASRerTwr}`,
+	}
+	fps := map[string]string{
+		"application.yaml": `openai:
+  api-key: ${OPENAI_API_KEY:default}`,
+		"application.yml": `openai:
+  api-key: ${OPENAI_API_KEY}`,
+	}
+
+	return utils.ValidateWithPaths(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -3058,6 +3058,16 @@ keywords = [
 ]
 
 [[rules]]
+id = "spring-placeholder-with-secret"
+description = "Secret embedded as default value in Spring Boot property placeholders, such as `${VAR:secret}` in YAML files."
+regex = '''(?i)\$\{[A-Z0-9_]+:([A-Za-z0-9+/=_-]{20,})\}'''
+path = '''(?i)\.ya?ml$'''
+secretGroup = 1
+tags = [
+    "secret","spring","placeholder","default-value",
+]
+
+[[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
 regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:[\x60'"\s;]|\\[nr]|$)'''


### PR DESCRIPTION
Add a new default detection rule for Spring Boot YAML placeholders that embed secrets in default values, such as `${OPENAI_API_KEY:gsk_...}`. This improves default scanning coverage for `.yaml` / `.yml` files and addresses issue #1361 by catching hardcoded secrets inside Spring property placeholders.