### PR TITLE
fix(config): treat empty [[rules]] blocks as no-ops

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,13 @@ func (vc *ViperConfig) Translate() (Config, error) {
 
 	// Validate individual rules.
 	for _, vr := range vc.Rules {
+		// Skip completely empty rule blocks (e.g., a bare [[rules]] entry with no fields set).
+		// These are treated as no-ops so that configs like `[[rules]]` paired with `useDefault = true`
+		// continue to work without error.
+		if vr.ID == "" && vr.Regex == "" && vr.Path == "" && len(vr.Keywords) == 0 && len(vr.Tags) == 0 {
+			continue
+		}
+
 		var (
 			pathPat  *regexp.Regexp
 			regexPat *regexp.Regexp

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,6 +89,15 @@ func TestTranslate(t *testing.T) {
 			},
 		},
 
+		// Empty [[rules]] block should be a no-op (regression: #1985)
+		{
+			cfgName: "valid/rule_empty_block",
+			cfg: Config{
+				Title: "Custom Gitleaks configuration",
+				Rules: map[string]Rule{},
+			},
+		},
+
 		// Invalid
 		{
 			cfgName:   "invalid/rule_missing_id",

--- a/testdata/config/valid/rule_empty_block.toml
+++ b/testdata/config/valid/rule_empty_block.toml
@@ -1,0 +1,4 @@
+title = "Custom Gitleaks configuration"
+
+# Empty [[rules]] block — should be treated as a no-op (regression: #1985)
+[[rules]]


### PR DESCRIPTION
## Problem

Since v8.29.0, a configuration file with a bare `[[rules]]` entry (no fields set) fails to load with:

```
FTL Failed to load config error="rule |id| is missing or empty"
```

This regressed from v8.28.0 where empty blocks were silently ignored. A common pattern is extending the default config and overriding a specific rule:

```toml
title = "Custom Gitleaks configuration"
[extend]
useDefault = true
[[rules]]
```

## Fix

In `config.Translate()`, skip `[[rules]]` entries where all identifying fields (`id`, `regex`, `path`, `keywords`, `tags`) are unset. These are genuine no-ops and should not trigger validation.

## Test plan

- [ ] Added `testdata/config/valid/rule_empty_block.toml` fixture with a bare `[[rules]]` entry
- [ ] Added test case in `TestTranslate` that verifies `Translate()` succeeds and returns an empty rules map
- [ ] Existing tests continue to pass (invalid rules with partial fields still error correctly)

Fixes #1985