### PR TITLE
fix(sources): propagate git stderr errors instead of swallowing them

### DIFF
--- a/sources/git.go
+++ b/sources/git.go
@@ -417,7 +417,10 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 				break
 			}
 
-			return yield(Fragment{}, err)
+			// Return the git error directly so it propagates up through DetectSource
+			// and the caller can exit with a non-zero exit code. Previously this went
+			// through yield() where the fragment callback swallowed it.
+			return err
 		}
 	}
 

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -1,6 +1,48 @@
 package sources
 
-// TODO: commenting out this test for now because it's flaky. Alternatives to consider to get this working:
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/fatih/semgroup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+// TestGitFragments_ErrorPropagation verifies that a git failure (e.g. running
+// in a directory that is not a git repository) propagates as a non-nil error
+// from Fragments() rather than being silently swallowed. Regression test for
+// https://github.com/gitleaks/gitleaks/issues/1981.
+func TestGitFragments_ErrorPropagation(t *testing.T) {
+	// Use a temp dir that is not a git repository.
+	dir, err := os.MkdirTemp("", "gitleaks-no-git-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ctx := context.Background()
+
+	gitCmd, err := NewGitLogCmdContext(ctx, dir, "")
+	require.NoError(t, err)
+
+	cfg := config.Config{}
+	src := &Git{
+		Cmd:    gitCmd,
+		Config: &cfg,
+		Sema:   semgroup.NewGroup(ctx, 1),
+	}
+
+	err = src.Fragments(ctx, func(_ Fragment, _ error) error {
+		return nil
+	})
+
+	assert.Error(t, err, "expected a non-nil error when git runs in a non-repository directory")
+}
+
+// TODO: the tests below are commented out because they are flaky.
+// Alternatives to consider to get this working:
 // -- use `git stash` instead of `restore()`
 
 // const repoBasePath = "../../testdata/repos/"


### PR DESCRIPTION
## Problem

When `gitleaks git` (or `gitleaks detect`) runs in a directory that is not a git repository (or git fails for any reason), gitleaks exits with code `0` and prints `no leaks found` — as if the scan succeeded.

```sh
$ gitleaks git --log-opts="--invalid" --verbose
...
ERR [git] fatal: not a git repository
ERR error="stderr is not empty"
INF no leaks found
$ echo $?
0
```

## Root cause

`sources.Git.Fragments()` sends git stderr errors through `yield(Fragment{}, err)`. The fragment callback in `detect.DetectSource` is designed to handle per-fragment errors gracefully — it logs them and returns `nil`. This means the git failure error was swallowed, `DetectSource` returned `nil`, and the command exited cleanly with `0`.

## Fix

Return the git error directly from `Fragments()` instead of routing it through the yield callback. This ensures the error propagates to `DetectSource` and then to the caller, which already calls `os.Exit(1)` when `err != nil`.

```go
// Before
return yield(Fragment{}, err)

// After
return err
```

## Test plan

- [ ] `TestGitFragments_ErrorPropagation`: runs `NewGitLogCmd` on a temp dir that is not a git repo, calls `Fragments()`, and asserts a non-nil error is returned

Fixes #1981