### PR TITLE
fix(docker): inject version via build-arg instead of git describe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.24 AS build
 WORKDIR /go/src/github.com/zricethezav/gitleaks
 COPY . .
-RUN VERSION=$(git describe --tags --abbrev=0) && \
+ARG VERSION
+RUN VERSION=${VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo "unknown")} && \
 CGO_ENABLED=0 go build -o bin/gitleaks -ldflags "-X=github.com/zricethezav/gitleaks/v8/version.Version=${VERSION}"
 
 FROM alpine:3.22


### PR DESCRIPTION
## Problem

The `--version` flag in Docker images since v8.29.0 returns the placeholder string instead of the actual version:

```sh
$ docker run ghcr.io/gitleaks/gitleaks:v8.29.0 --version
gitleaks version version is set by build process
```

## Root cause

The Dockerfile uses `git describe --tags --abbrev=0` to find the version tag at build time:

```dockerfile
RUN VERSION=$(git describe --tags --abbrev=0) && \
    CGO_ENABLED=0 go build -o bin/gitleaks -ldflags "-X=...version.Version=${VERSION}"
```

`docker/build-push-action` in the release workflow performs a shallow clone (`fetch-depth: 1` by default), so git tags are not available inside the build context. `git describe` fails silently, `VERSION` is empty, and the ldflags substitution never replaces the placeholder.

## Fix

- Add `ARG VERSION` to the Dockerfile so the version can be injected as a build argument
- Fall back to `git describe` for local builds, and then `"unknown"` if that also fails
- Pass `VERSION=${{ github.ref_name }}` from the release workflow via `build-args`

## Test plan

- [ ] Build locally: `docker build --build-arg VERSION=v9.0.0-test . && docker run <img> --version` → should print `gitleaks version v9.0.0-test`
- [ ] Build without arg: `docker build .` → falls back to `git describe` or `unknown`
- [ ] CI: release workflow now passes the tag name as `VERSION`

Fixes #1984