### PR TITLE
fix(config): return error on invalid regex instead of panicking

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -119,12 +119,17 @@ func (vc *ViperConfig) Translate() (Config, error) {
 		var (
 			pathPat  *regexp.Regexp
 			regexPat *regexp.Regexp
+			err      error
 		)
 		if vr.Path != "" {
-			pathPat = regexp.MustCompile(vr.Path)
+			if pathPat, err = regexp.Compile(vr.Path); err != nil {
+				return Config{}, fmt.Errorf("rule %q: invalid |path| regex: %w", vr.ID, err)
+			}
 		}
 		if vr.Regex != "" {
-			regexPat = regexp.MustCompile(vr.Regex)
+			if regexPat, err = regexp.Compile(vr.Regex); err != nil {
+				return Config{}, fmt.Errorf("rule %q: invalid |regex|: %w", vr.ID, err)
+			}
 		}
 		if vr.Keywords == nil {
 			vr.Keywords = []string{}
@@ -339,12 +344,20 @@ func (vc *ViperConfig) parseAllowlist(a *viperRuleAllowlist) (*Allowlist, error)
 		}
 	}
 	var allowlistRegexes []*regexp.Regexp
-	for _, a := range a.Regexes {
-		allowlistRegexes = append(allowlistRegexes, regexp.MustCompile(a))
+	for _, r := range a.Regexes {
+		compiled, err := regexp.Compile(r)
+		if err != nil {
+			return nil, fmt.Errorf("invalid allowlist |regexes| pattern %q: %w", r, err)
+		}
+		allowlistRegexes = append(allowlistRegexes, compiled)
 	}
 	var allowlistPaths []*regexp.Regexp
-	for _, a := range a.Paths {
-		allowlistPaths = append(allowlistPaths, regexp.MustCompile(a))
+	for _, p := range a.Paths {
+		compiled, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid allowlist |paths| pattern %q: %w", p, err)
+		}
+		allowlistPaths = append(allowlistPaths, compiled)
 	}
 
 	allowlist := &Allowlist{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -314,6 +314,12 @@ func TestTranslateAllowlists(t *testing.T) {
 			cfg:       Config{},
 			wantError: errors.New("example: [[rules.allowlists]] unknown allowlist |regexTarget| 'mtach' (expected 'match', 'line')"),
 		},
+		// Bad regex in allowlist paths should return an error, not panic (regression: #1846)
+		{
+			cfgName:   "invalid/allowlist_bad_regex",
+			cfg:       Config{},
+			wantError: errors.New(`[[allowlists]] invalid allowlist |paths| pattern "*.test.js": error parsing regexp: missing argument to repetition operator: ` + "`*`"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/regexp/stdlib_regex.go
+++ b/regexp/stdlib_regex.go
@@ -10,6 +10,10 @@ const Version = "stdlib"
 
 type Regexp = re.Regexp
 
+func Compile(str string) (*re.Regexp, error) {
+	return re.Compile(str)
+}
+
 func MustCompile(str string) *re.Regexp {
 	return re.MustCompile(str)
 }

--- a/regexp/wasilibs_regex.go
+++ b/regexp/wasilibs_regex.go
@@ -10,6 +10,10 @@ const Version = "github.com/wasilibs/go-re2"
 
 type Regexp = re.Regexp
 
+func Compile(str string) (*re.Regexp, error) {
+	return re.Compile(str)
+}
+
 func MustCompile(str string) *re.Regexp {
 	return re.MustCompile(str)
 }

--- a/testdata/config/invalid/allowlist_bad_regex.toml
+++ b/testdata/config/invalid/allowlist_bad_regex.toml
@@ -1,0 +1,9 @@
+[extend]
+useDefault = true
+
+[allowList]
+paths = [
+    '''.*/test/.*''',
+    '''*.test.js''',
+    '''*.stories.js'''
+]


### PR DESCRIPTION
## Problem

A bad regular expression in a config file causes an unrecovered `panic` and a raw stack trace instead of a friendly error message:

```toml
[allowList]
paths = [
    '''.*/test/.*''',
    '''*.test.js''',
    '''*.stories.js'''
]
```

```
panic: regexp: Compile(`*.test.js`): error parsing regexp: missing argument to repetition operator: `*`

goroutine 1 [running]:
regexp.MustCompile(...)
    regexp/regexp.go:313 +0xb0
github.com/zricethezav/gitleaks/v8/config.(*ViperConfig).Translate(_)
    config/config.go:189 +0x57c
```

This affects:
- `[[allowlists]] paths` and `regexes`
- `[[rules]] path` and `regex`

## Fix

- Add `Compile(str) (*Regexp, error)` to both regexp backends (`stdlib_regex.go`, `wasilibs_regex.go`)
- Replace all four `regexp.MustCompile` calls in `config.Translate()` and `parseAllowlist()` with `regexp.Compile`, returning a descriptive error that includes the offending pattern

**Before:**
```
panic: regexp: Compile(`*.test.js`): error parsing regexp: ...
```

**After:**
```
FTL Failed to load config error="[[allowlists]] invalid allowlist |paths| pattern \"*.test.js\": error parsing regexp: missing argument to repetition operator: `*`"
```

## Test plan

- [ ] Added `testdata/config/invalid/allowlist_bad_regex.toml` with the exact config from the issue report
- [ ] Added test case in `TestTranslateAllowlists` asserting a clean error (not a panic) is returned
- [ ] Rule-level `path`/`regex` fields follow the same pattern (covered by existing rule validation tests)

Fixes #1846