### PR TITLE
fix(rules): remove bare-hex alternative from sourcegraph-access-token

### DIFF
--- a/cmd/generate/config/rules/sourcegraph.go
+++ b/cmd/generate/config/rules/sourcegraph.go
@@ -10,7 +10,7 @@ func SourceGraph() *config.Rule {
 	r := config.Rule{
 		RuleID:      "sourcegraph-access-token",
 		Description: "Sourcegraph is a code search and navigation engine.",
-		Regex:       utils.GenerateUniqueTokenRegex(`\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}|[a-fA-F0-9]{40})\b`, true),
+		Regex:       utils.GenerateUniqueTokenRegex(`\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})\b`, true),
 		Entropy:     3,
 		Keywords:    []string{"sgp_", "sourcegraph"},
 	}
@@ -18,17 +18,17 @@ func SourceGraph() *config.Rule {
 	// validate
 	tps := []string{
 		`sgp_AaD80dc6E02eCAE1_d3cba16CC0F18fA14A2EFB61CbDFceEBf9fAD16b`,
-		`sourcegraph: 6d2FabeB6ADd229Bc199FabA28fD3efb57dF0bD3`,
 		`sgp_0D697F54cb24238EefB29af05Abf1b505E90950F`,
 		`sgp_local_d7dfFD43cF2503B1da673EB560aAa3e80f16FA42`,
 		`sgp_local_bcD1DA18de0d6476Be0f3BD7Ef9Da4f09b479aE5`,
 	}
 	fps := []string{
 		`sgp_5555555dAAAAA7777777CcccCFaaaaaaaaaaaaaa`,                    // low entropy
-		`sgp_local_d45b6G86aBb0F2Cee943902dbaDBCFCFDD1dA089`,              // invalid case
+		`sgp_local_d45b6G86aBb0F2Cee943902dbaDBCFCFDD1dA089`,              // invalid char in hex segment
 		`sgp_652d9a2e48FC7E!FcDbEA1BC2E2A6CE23cFe7F7D`,                    // invalid character
 		`sgp_78Ad84a5B6e8A2fE5B_4085FB0ccaDDd29DB66Fd7FE9bA2C1cdCE8400CD`, // invalid length
-		`BcAeb6640ad7DAD46AD73687946Ce85047d5C9Bb`,
+		`sourcegraph: 6d2FabeB6ADd229Bc199FabA28fD3efb57dF0bD3`,            // bare hex without sgp_ prefix — false positive (e.g. git SHA)
+		`BcAeb6640ad7DAD46AD73687946Ce85047d5C9Bb`,                         // bare hex without sgp_ prefix — false positive (e.g. git SHA)
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -3050,7 +3050,7 @@ keywords = ["sonar"]
 [[rules]]
 id = "sourcegraph-access-token"
 description = "Sourcegraph is a code search and navigation engine."
-regex = '''(?i)\b(\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}|[a-fA-F0-9]{40})\b)(?:[\x60'"\s;]|\\[nr]|$)'''
+regex = '''(?i)\b(\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})\b)(?:[\x60'"\s;]|\\[nr]|$)'''
 entropy = 3
 keywords = [
     "sgp_",


### PR DESCRIPTION
## Problem

The `sourcegraph-access-token` rule false-positives on git commit SHAs. Any 40-character hex string in a file that also contains `sourcegraph` or `sgp_` anywhere in the scanned chunk triggers a finding.

The culprit is the third alternative in the regex:

```
sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}   ← new format (user + token)
sgp_[a-fA-F0-9]{40}                               ← old sgp_ format
[a-fA-F0-9]{40}                                   ← ⚠️ matches ANY 40-char hex, incl. git SHAs
```

## Fix

Remove the bare `[a-fA-F0-9]{40}` alternative. All current Sourcegraph token formats carry an `sgp_` prefix. The bare hex form covered a legacy token format that is structurally identical to a git commit SHA and cannot be distinguished from one without surrounding context.

- `cmd/generate/config/rules/sourcegraph.go`: narrowed regex, moved bare-hex example from TPs → FPs with explanatory comment
- `config/gitleaks.toml`: regenerated to match

## Before / After

```
# Before — matches git SHA in a file containing "sourcegraph"
regex = '''(?i)\b(\b(sgp_...|sgp_...|[a-fA-F0-9]{40})\b)...'''

# After — only matches sgp_-prefixed tokens
regex = '''(?i)\b(\b(sgp_...|sgp_...)\b)...'''
```

Fixes #1898