### PR TITLE
fix: return non-zero when git scans fail

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -226,8 +226,13 @@ func (d *Detector) DetectSource(ctx context.Context, source sources.Source) ([]r
 		logger := logContext.Logger()
 
 		if err != nil {
-			// Log the error and move on to the next fragment
+			// Fragment-scoped errors can be logged and skipped so the scan can
+			// continue, but source-level errors arrive without fragment context
+			// and must abort the scan.
 			logger.Error().Err(err).Send()
+			if fragment.FilePath == "" && fragment.CommitSHA == "" && len(fragment.Raw) == 0 && len(fragment.Bytes) == 0 {
+				return err
+			}
 			return nil
 		}
 

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -3,6 +3,7 @@ package detect
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -127,6 +128,40 @@ func compare(t *testing.T, a, b []report.Finding) {
 		t.Errorf("findings mismatch (-want +got):\n%s", diff)
 	}
 
+}
+
+type sourceFunc func(context.Context, sources.FragmentsFunc) error
+
+func (f sourceFunc) Fragments(ctx context.Context, yield sources.FragmentsFunc) error {
+	return f(ctx, yield)
+}
+
+func TestDetectSourceReturnsSourceLevelErrors(t *testing.T) {
+	detector, err := NewDetectorDefaultConfig()
+	require.NoError(t, err)
+
+	sourceErr := errors.New("stderr is not empty")
+
+	findings, err := detector.DetectSource(context.Background(), sourceFunc(func(ctx context.Context, yield sources.FragmentsFunc) error {
+		return yield(sources.Fragment{}, sourceErr)
+	}))
+
+	require.ErrorIs(t, err, sourceErr)
+	require.Empty(t, findings)
+}
+
+func TestDetectSourceIgnoresFragmentScopedErrors(t *testing.T) {
+	detector, err := NewDetectorDefaultConfig()
+	require.NoError(t, err)
+
+	fragmentErr := errors.New("could not read file")
+
+	findings, err := detector.DetectSource(context.Background(), sourceFunc(func(ctx context.Context, yield sources.FragmentsFunc) error {
+		return yield(sources.Fragment{FilePath: "README.md"}, fragmentErr)
+	}))
+
+	require.NoError(t, err)
+	require.Empty(t, findings)
 }
 
 func TestDetect(t *testing.T) {


### PR DESCRIPTION
### Description:

Fixes #1464.

Git-backed scans currently swallow source-level errors because `DetectSource()` treats every callback error as fragment-local. As a result, commands like `gitleaks git --log-opts='--definitely-not-a-real-git-log-flag' .` log `stderr is not empty` but still exit 0. This change only returns errors that arrive without fragment context, so git scan failures now terminate with exit code 1 while fragment-scoped read errors continue to be logged and skipped. It also adds regression tests for both behaviors.

Validated with `go test ./...`, `go test -race ./...`, the original `gitleaks detect -s --no-banner . -c config.toml` repro from #1464, and a current `gitleaks git --log-opts=...` repro on `master`.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
