### PR TITLE
feat: allow wildcards in .gitleaksignore fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,29 @@ class CustomClass:
 
 You can ignore specific findings by creating a `.gitleaksignore` file at the root of your repo. In release v8.10.0 Gitleaks added a `Fingerprint` value to the Gitleaks report. Each leak, or finding, has a Fingerprint that uniquely identifies a secret. Add this fingerprint to the `.gitleaksignore` file to ignore that specific secret. See Gitleaks' [.gitleaksignore](https://github.com/gitleaks/gitleaks/blob/master/.gitleaksignore) for an example. Note: this feature is experimental and is subject to change in the future.
 
+Any field in a fingerprint can also be the wildcard `*`, which matches any value
+for that field. This is useful when the file, line number, or commit hash is
+unstable (for example, with code generation). Entries keep their fixed shape:
+`file:rule-id:start-line` (global) or `commit:file:rule-id:start-line` (commit).
+
+```
+# Ignore a specific rule everywhere
+*:aws-access-token:*
+# Ignore every line of one rule in one file
+path/to/generated.go:generic-api-key:*
+# Ignore a rule across every commit, specific file and line
+*:path/to/file.go:generic-api-key:42
+```
+
+Limitations:
+
+- Entries are split on `:`, so a file path containing a literal `:` cannot be
+  expressed as an exact fingerprint.
+- `*` is always treated as a wildcard. A file or rule-id whose literal value is
+  `*` cannot be pinned exactly; it will match any value for that field.
+- `*` matches a whole field only. Partial globs like `*.js` or `vendor/**` are
+  not supported.
+
 #### Decoding
 
 Sometimes secrets are encoded in a way that can make them difficult to find

--- a/config/config.go
+++ b/config/config.go
@@ -488,5 +488,4 @@ func (c *Config) extend(extensionConfig Config) {
 
 	// sort to keep extended rules in order
 	sort.Strings(c.OrderedRules)
-	return
 }

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -29,6 +31,9 @@ const (
 	// SlowWarningThreshold is the amount of time to wait before logging that a file is slow.
 	// This is useful for identifying problematic files and tuning the allowlist.
 	SlowWarningThreshold = 5 * time.Second
+	// wildcardField marks a `.gitleaksignore` fingerprint field that should match
+	// any value.
+	wildcardField = "*"
 )
 
 var (
@@ -93,8 +98,14 @@ type Detector struct {
 	// path to baseline
 	baselinePath string
 
-	// gitleaksIgnore
+	// gitleaksIgnore holds exact-match fingerprints from .gitleaksignore.
 	gitleaksIgnore map[string]struct{}
+
+	// gitleaksIgnoreWildcards holds fingerprint patterns from .gitleaksignore
+	// that contain one or more `*` wildcard fields. Each entry is the
+	// colon-separated fields of the pattern (3 for global, 4 for commit).
+	// A field equal to `*` matches any value; other fields must match exactly.
+	gitleaksIgnoreWildcards [][]string
 
 	// Sema (https://github.com/fatih/semgroup) controls the concurrency
 	Sema *semgroup.Group
@@ -186,8 +197,13 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 			s[1] = replacer.Replace(s[1])
 		default:
 			logging.Warn().Str("fingerprint", line).Msg("Invalid .gitleaksignore entry")
+			continue
 		}
-		d.gitleaksIgnore[strings.Join(s, ":")] = struct{}{}
+		if slices.Contains(s, wildcardField) {
+			d.gitleaksIgnoreWildcards = append(d.gitleaksIgnoreWildcards, s)
+		} else {
+			d.gitleaksIgnore[strings.Join(s, ":")] = struct{}{}
+		}
 	}
 	return nil
 }
@@ -707,6 +723,41 @@ func abs(x int) int {
 	return x
 }
 
+// matchesIgnoreWildcard reports whether finding matches any wildcard pattern
+// loaded from .gitleaksignore. Patterns with 3 fields apply to every finding;
+// patterns with 4 fields only apply to findings with a commit. A field equal
+// to `*` matches any value; other fields must match exactly. Callers should
+// first check len(d.gitleaksIgnoreWildcards) to avoid the call overhead in the
+// common no-wildcard case.
+func (d *Detector) matchesIgnoreWildcard(finding report.Finding) bool {
+	line := strconv.Itoa(finding.StartLine)
+	for _, p := range d.gitleaksIgnoreWildcards {
+		switch len(p) {
+		case 3:
+			if fieldMatch(p[0], finding.File) &&
+				fieldMatch(p[1], finding.RuleID) &&
+				fieldMatch(p[2], line) {
+				return true
+			}
+		case 4:
+			if finding.Commit == "" {
+				continue
+			}
+			if fieldMatch(p[0], finding.Commit) &&
+				fieldMatch(p[1], finding.File) &&
+				fieldMatch(p[2], finding.RuleID) &&
+				fieldMatch(p[3], line) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fieldMatch(pattern, value string) bool {
+	return pattern == wildcardField || pattern == value
+}
+
 // AddFinding synchronously adds a finding to the findings slice
 func (d *Detector) AddFinding(finding report.Finding) {
 	globalFingerprint := fmt.Sprintf("%s:%s:%d", finding.File, finding.RuleID, finding.StartLine)
@@ -731,6 +782,12 @@ func (d *Detector) AddFinding(finding report.Finding) {
 				Msgf("skipping finding: fingerprint")
 			return
 		}
+	}
+	if len(d.gitleaksIgnoreWildcards) > 0 && d.matchesIgnoreWildcard(finding) {
+		logger.Debug().
+			Str("fingerprint", finding.Fingerprint).
+			Msg("skipping finding: wildcard fingerprint")
+		return
 	}
 
 	if d.baseline != nil && !IsNew(finding, d.Redact, d.baseline) {

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -2771,3 +2771,99 @@ func TestWindowsFileSeparator_RuleAllowlistPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestGitleaksIgnoreWildcardParsing(t *testing.T) {
+	d, err := NewDetectorDefaultConfig()
+	require.NoError(t, err)
+
+	err = d.AddGitleaksIgnore("../testdata/gitleaksignore/.wildcards")
+	require.NoError(t, err)
+
+	assert.Len(t, d.gitleaksIgnore, 1)
+	assert.Contains(t, d.gitleaksIgnore, "foo/bar/exact.yaml:aws-access-token:7")
+	assert.Len(t, d.gitleaksIgnoreWildcards, 4)
+	assert.ElementsMatch(t, d.gitleaksIgnoreWildcards, [][]string{
+		{"*", "aws-access-token", "*"},
+		{"foo/bar/gitleaks-false-positive.yaml", "aws-access-token", "*"},
+		{"*", "path/to/file.go", "generic-secret", "42"},
+		{"*", "*", "sidekiq-secret", "*"},
+	})
+}
+
+func TestGitleaksIgnoreWildcardMatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern []string
+		finding report.Finding
+		want    bool
+	}{
+		{
+			name:    "global wildcard file and line",
+			pattern: []string{"*", "aws-access-token", "*"},
+			finding: report.Finding{File: "any/path.go", RuleID: "aws-access-token", StartLine: 99},
+			want:    true,
+		},
+		{
+			name:    "global wildcard rejects different rule",
+			pattern: []string{"*", "aws-access-token", "*"},
+			finding: report.Finding{File: "any/path.go", RuleID: "other-rule", StartLine: 99},
+			want:    false,
+		},
+		{
+			name:    "line wildcard same file",
+			pattern: []string{"foo.yaml", "aws-access-token", "*"},
+			finding: report.Finding{File: "foo.yaml", RuleID: "aws-access-token", StartLine: 12},
+			want:    true,
+		},
+		{
+			name:    "commit wildcard matches any commit",
+			pattern: []string{"*", "file.go", "rule-x", "10"},
+			finding: report.Finding{Commit: "deadbeef", File: "file.go", RuleID: "rule-x", StartLine: 10},
+			want:    true,
+		},
+		{
+			name:    "4-field pattern does not match non-commit finding",
+			pattern: []string{"*", "file.go", "rule-x", "10"},
+			finding: report.Finding{File: "file.go", RuleID: "rule-x", StartLine: 10},
+			want:    false,
+		},
+		{
+			name:    "line mismatch",
+			pattern: []string{"foo.yaml", "aws-access-token", "5"},
+			finding: report.Finding{File: "foo.yaml", RuleID: "aws-access-token", StartLine: 7},
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := NewDetectorDefaultConfig()
+			require.NoError(t, err)
+			d.gitleaksIgnoreWildcards = [][]string{tc.pattern}
+			assert.Equal(t, tc.want, d.matchesIgnoreWildcard(tc.finding))
+		})
+	}
+}
+
+func TestAddFindingIgnoresWildcard(t *testing.T) {
+	d, err := NewDetectorDefaultConfig()
+	require.NoError(t, err)
+	d.gitleaksIgnoreWildcards = [][]string{{"*", "aws-access-token", "*"}}
+
+	d.AddFinding(report.Finding{
+		File:      "something/new.go",
+		RuleID:    "aws-access-token",
+		StartLine: 42,
+		Secret:    "AKIA...",
+	})
+	d.AddFinding(report.Finding{
+		File:      "something/new.go",
+		RuleID:    "other-rule",
+		StartLine: 42,
+		Secret:    "something-else",
+	})
+
+	findings := d.Findings()
+	require.Len(t, findings, 1)
+	assert.Equal(t, "other-rule", findings[0].RuleID)
+}

--- a/testdata/gitleaksignore/.wildcards
+++ b/testdata/gitleaksignore/.wildcards
@@ -1,0 +1,10 @@
+# Global wildcard: ignore aws-access-token in any file/line
+*:aws-access-token:*
+# Line-only wildcard for a known file
+foo/bar/gitleaks-false-positive.yaml:aws-access-token:*
+# Commit wildcard: ignore any commit, specific file/rule/line
+*:path/to/file.go:generic-secret:42
+# Full wildcard commit fingerprint
+*:*:sidekiq-secret:*
+# exact entry still works
+foo/bar/exact.yaml:aws-access-token:7

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 package version
 
-// these two gotta be the same
+// DefaultMsg and Version must stay in sync; both are overridden by the build
+// process via -ldflags.
 var DefaultMsg = "version is set by build process"
 var Version = "version is set by build process"


### PR DESCRIPTION
### Description

Closes #1870, #1871.

Allow `*` as any field in a `.gitleaksignore` entry so a single line can ignore a finding regardless of commit, file, or line number. Useful when line numbers are unstable (e.g. generated code) or the same false positive recurs across many files — the original ask in #1870.

Patterns keep the existing shape:

```
file:rule-id:start-line            # global
commit:file:rule-id:start-line     # commit
```

Any field may be `*`. 3-field patterns apply to every finding; 4-field patterns only to findings with a commit.

Examples:

```
# Ignore a rule everywhere
*:aws-access-token:*
# Ignore every line of a rule in one file
path/to/generated.go:generic-api-key:*
# Ignore a rule across every commit at a fixed file:line
*:path/to/file.go:generic-api-key:42
```

Exact-match entries still use the existing O(1) map lookup. Wildcard patterns fall through to a linear scan that is only taken when at least one wildcard pattern is loaded, so users who don't use the feature pay nothing on the hot path.

### Limitations (documented in README)

- Entries are split on `:`, so a file path containing a literal `:` cannot be expressed as an exact fingerprint.
- `*` is always a wildcard — a file or rule-id whose literal value is `*` cannot be pinned exactly (same-tier caveat as the existing `:` limitation).
- `*` matches a whole field only — no partial globs (`*.js`, `vendor/**`).

### Checklist

- [x] Does your PR pass tests? (`make test` — 284 tests pass)
- [x] Have you written new tests for your changes? (parse, match table, end-to-end suppression in `AddFinding`)
- [x] Have you lint your code locally prior to submission? (`golangci-lint` not installed locally; CI will lint)