### PR TITLE
feat: add Claude Code session URL detection

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -55,6 +55,7 @@ func main() {
 		rules.Beamer(),
 		rules.CodecovAccessToken(),
 		rules.CoinbaseAccessToken(),
+		rules.ClaudeCodeSessionURL(),
 		rules.ClickHouseCloud(),
 		rules.Clojars(),
 		rules.CloudflareAPIKey(),

--- a/cmd/generate/config/rules/claude.go
+++ b/cmd/generate/config/rules/claude.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+func ClaudeCodeSessionURL() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Identified a Claude Code session URL, which could allow unauthorized remote-control access to an active Claude Code session if leaked.",
+		RuleID:      "claude-code-session-url",
+		Regex:       regexp.MustCompile(`(?i)\bhttps?://claude\.ai/code/session_[A-Za-z0-9]{16,}\b`),
+		Keywords:    []string{"claude.ai/code/session_"},
+	}
+
+	// validate
+	tps := []string{
+		"https://claude.ai/code/session_01DDpXdCk8uhiRdzku123456",
+		"http://claude.ai/code/session_01DDpXdCk8uhiRdzku123456",
+		"see https://claude.ai/code/session_01DDpXdCk8uhiRdzku123456 for context",
+		`session = "https://claude.ai/code/session_01DDpXdCk8uhiRdzku123456"`,
+		"https://CLAUDE.AI/code/session_01DDpXdCk8uhiRdzku123456",
+		"https://claude.ai/code/session_01DDpXdCk8uhiRdzku123456/",
+		"https://claude.ai/code/session_01DDpXdCk8uhiRdzku123456?ref=foo",
+		"https://claude.ai/code/session_" + secrets.NewSecret(`[A-Za-z0-9]{24}`),
+	}
+	fps := []string{
+		// Wrong host
+		"https://example.com/code/session_01DDpXdCk8uhiRdzku123456",
+		// Wrong path prefix
+		"https://claude.ai/chat/session_01DDpXdCk8uhiRdzku123456",
+		// Missing session_ prefix
+		"https://claude.ai/code/01DDpXdCk8uhiRdzku123456",
+		// ID too short to be plausible
+		"https://claude.ai/code/session_short",
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -278,6 +278,12 @@ entropy = 3
 keywords = ["meraki"]
 
 [[rules]]
+id = "claude-code-session-url"
+description = "Identified a Claude Code session URL, which could allow unauthorized remote-control access to an active Claude Code session if leaked."
+regex = '''(?i)\bhttps?://claude\.ai/code/session_[A-Za-z0-9]{16,}\b'''
+keywords = ["claude.ai/code/session_"]
+
+[[rules]]
 id = "clickhouse-cloud-api-secret-key"
 description = "Identified a pattern that may indicate clickhouse cloud API secret key, risking unauthorized clickhouse cloud api access and data breaches on ClickHouse Cloud platforms."
 regex = '''\b(4b1d[A-Za-z0-9]{38})\b'''


### PR DESCRIPTION
## Summary

Adds a Gitleaks rule to detect Claude Code Remote Control session URLs (`https://claude.ai/code/session_<id>`). These URLs act as bearer credentials for an active local Claude Code session — opening one grants full control over the session host's filesystem, tool execution, and configured MCP servers, without needing any other credentials.

Closes #2094.

## Rule

- **Rule ID:** `claude-code-session-url`
- **Pattern:** `(?i)\bhttps?://claude\.ai/code/session_[A-Za-z0-9]{16,}\b`
- **Keywords:** `claude.ai/code/session_`

## Scope and Possible Additional Formats

This PR covers the one Remote Control URL format I confirmed directly from running Claude Code. There are likely other URL forms also worth detecting that I haven't been able to verify:

- **Cloud sessions** at `claude.ai/code/<id>` (no `session_` prefix), used by `claude --remote` / `--teleport`. ID format unknown — left out to avoid generic false positives on the bare `claude.ai/code` path.
- **Possible additional Remote Control URL forms** referenced by third-party write-ups (`app.claude.com/rc/<id>`, `claude.ai/remote/<id>`). Could not verify against Anthropic's official documentation or my own session output, so not included.

Happy to add alternations as follow-ups once formats are confirmed. Input from maintainers or anyone with direct knowledge of Anthropic's Remote Control / cloud session URL schemes very welcome — see issue #2094 for more context.

## Files

- `cmd/generate/config/rules/claude.go` — new rule generator with true/false positive samples
- `cmd/generate/config/main.go` — registers `rules.ClaudeCodeSessionURL()`
- `config/gitleaks.toml` — regenerated via `go generate ./...`

## Test plan

- [x] `utils.Validate` passes for all true positives (correct format, mixed case, http/https, embedded in source, trailing slash and query string) and rejects all false positives (wrong host, wrong path, missing prefix, too-short IDs)
- [x] `make test` passes locally
- [x] End-to-end smoke test: `gitleaks detect` against a file containing a sample URL flags the leak with `RuleID: claude-code-session-url`