### PR TITLE
Emit composite rule requirements in generated config

### DIFF
--- a/cmd/generate/config/main_test.go
+++ b/cmd/generate/config/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+func TestConfigTemplateIncludesRequiredRules(t *testing.T) {
+	withinLines := 3
+	withinColumns := 24
+	cfg := config.Config{
+		Title: "test config",
+		Rules: map[string]config.Rule{
+			"primary-rule": {
+				RuleID:      "primary-rule",
+				Description: "Primary rule",
+				Regex:       regexp.MustCompile(`primary-([a-z]+)`),
+				RequiredRules: []*config.Required{
+					{
+						RuleID:        "required-rule",
+						WithinLines:   &withinLines,
+						WithinColumns: &withinColumns,
+					},
+				},
+			},
+			"required-rule": {
+				RuleID:      "required-rule",
+				Description: "Required rule",
+				Regex:       regexp.MustCompile(`required-([a-z]+)`),
+			},
+		},
+	}
+
+	output := renderConfigTemplate(t, cfg)
+	assert.Contains(t, output, "[[rules.required]]")
+	assert.Contains(t, output, `id = "required-rule"`)
+	assert.Contains(t, output, "withinLines = 3")
+	assert.Contains(t, output, "withinColumns = 24")
+
+	v := viper.New()
+	v.SetConfigType("toml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(output)))
+
+	var vc config.ViperConfig
+	require.NoError(t, v.Unmarshal(&vc))
+	parsed, err := vc.Translate()
+	require.NoError(t, err)
+
+	primaryRule := parsed.Rules["primary-rule"]
+	require.Len(t, primaryRule.RequiredRules, 1)
+	require.NotNil(t, primaryRule.RequiredRules[0].WithinLines)
+	require.NotNil(t, primaryRule.RequiredRules[0].WithinColumns)
+	assert.Equal(t, "required-rule", primaryRule.RequiredRules[0].RuleID)
+	assert.Equal(t, withinLines, *primaryRule.RequiredRules[0].WithinLines)
+	assert.Equal(t, withinColumns, *primaryRule.RequiredRules[0].WithinColumns)
+}
+
+func renderConfigTemplate(t *testing.T, cfg config.Config) string {
+	t.Helper()
+
+	tmpl, err := template.ParseFiles(templatePath)
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	require.NoError(t, tmpl.Execute(&output, cfg))
+	return output.String()
+}

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -56,6 +56,13 @@ keywords = [{{ range $j, $keyword := . }}"{{ $keyword }}"{{ end }}]{{end}}{{ end
 tags = [
     {{ range $j, $tag := . }}"{{ $tag }}",{{ end }}
 ]{{ end }}
+{{- with $rule.RequiredRules }}{{ range $i, $required := . }}{{println}}[[rules.required]]
+id = "{{$required.RuleID}}"
+{{- with $required.WithinLines }}
+withinLines = {{ . }}{{ end -}}
+{{- with $required.WithinColumns }}
+withinColumns = {{ . }}{{ end }}
+{{- end }}{{ end }}
 {{- with $rule.Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}{{println}}[[rules.allowlists]]
 {{- with .Description }}{{println}}description = "{{ . }}"{{ end }}
 {{- with .MatchCondition }}{{println}}condition = "{{ .String }}"{{ end }}

--- a/cmd/generate/config/utils/validate.go
+++ b/cmd/generate/config/utils/validate.go
@@ -13,9 +13,9 @@ import (
 	"github.com/zricethezav/gitleaks/v8/logging"
 )
 
-func Validate(rule config.Rule, truePositives []string, falsePositives []string) *config.Rule {
+func Validate(rule config.Rule, truePositives []string, falsePositives []string, requiredRules ...*config.Rule) *config.Rule {
 	r := &rule
-	d := createSingleRuleDetector(r)
+	d := createSingleRuleDetector(r, requiredRules...)
 	for _, tp := range truePositives {
 		if len(d.DetectString(tp)) < 1 {
 			logging.Fatal().
@@ -38,9 +38,9 @@ func Validate(rule config.Rule, truePositives []string, falsePositives []string)
 	return r
 }
 
-func ValidateWithPaths(rule config.Rule, truePositives map[string]string, falsePositives map[string]string) *config.Rule {
+func ValidateWithPaths(rule config.Rule, truePositives map[string]string, falsePositives map[string]string, requiredRules ...*config.Rule) *config.Rule {
 	r := &rule
-	d := createSingleRuleDetector(r)
+	d := createSingleRuleDetector(r, requiredRules...)
 	for path, tp := range truePositives {
 		f := detect.Fragment{Raw: tp, FilePath: path}
 		if len(d.Detect(f)) != 1 {
@@ -66,28 +66,43 @@ func ValidateWithPaths(rule config.Rule, truePositives map[string]string, falseP
 	return r
 }
 
-func createSingleRuleDetector(r *config.Rule) *detect.Detector {
+func createSingleRuleDetector(r *config.Rule, requiredRules ...*config.Rule) *detect.Detector {
 	// normalize keywords like in the config package
 	var (
-		uniqueKeywords = make(map[string]struct{})
-		keywords       []string
+		configKeywords = make(map[string]struct{})
 	)
-	for _, keyword := range r.Keywords {
-		k := strings.ToLower(keyword)
-		if _, ok := uniqueKeywords[k]; ok {
-			continue
+	normalizeKeywords := func(rule *config.Rule) {
+		var (
+			uniqueKeywords = make(map[string]struct{})
+			keywords       []string
+		)
+		for _, keyword := range rule.Keywords {
+			k := strings.ToLower(keyword)
+			configKeywords[k] = struct{}{}
+			if _, ok := uniqueKeywords[k]; ok {
+				continue
+			}
+			keywords = append(keywords, k)
+			uniqueKeywords[k] = struct{}{}
 		}
-		keywords = append(keywords, k)
-		uniqueKeywords[k] = struct{}{}
+		rule.Keywords = keywords
 	}
-	r.Keywords = keywords
+	normalizeKeywords(r)
 
 	rules := map[string]config.Rule{
 		r.RuleID: *r,
 	}
+	for _, requiredRule := range requiredRules {
+		if requiredRule == nil {
+			continue
+		}
+		normalizeKeywords(requiredRule)
+		rules[requiredRule.RuleID] = *requiredRule
+	}
+
 	cfg := base.CreateGlobalConfig()
 	cfg.Rules = rules
-	cfg.Keywords = uniqueKeywords
+	cfg.Keywords = configKeywords
 	for _, a := range cfg.Allowlists {
 		if err := a.Validate(); err != nil {
 			logging.Fatal().Err(err).Msg("invalid global allowlist")

--- a/cmd/generate/config/utils/validate_test.go
+++ b/cmd/generate/config/utils/validate_test.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+func TestValidateAcceptsCompositeRules(t *testing.T) {
+	withinLines := 1
+	requiredRule := config.Rule{
+		RuleID:      "username-rule",
+		Description: "Username rule",
+		Regex:       regexp.MustCompile(`username\s*=\s*"([^"]+)"`),
+		SkipReport:  true,
+	}
+	primaryRule := config.Rule{
+		RuleID:      "primary-rule",
+		Description: "Primary rule",
+		Regex:       regexp.MustCompile(`password\s*=\s*"([^"]+)"`),
+		RequiredRules: []*config.Required{
+			{
+				RuleID:      requiredRule.RuleID,
+				WithinLines: &withinLines,
+			},
+		},
+	}
+
+	rule := Validate(
+		primaryRule,
+		[]string{`username = "admin"` + "\n" + `password = "secret"`},
+		[]string{`password = "secret"`, `username = "admin"`},
+		&requiredRule,
+	)
+
+	if len(rule.RequiredRules) != 1 {
+		t.Fatalf("expected required rule to be kept, got %d", len(rule.RequiredRules))
+	}
+}


### PR DESCRIPTION
### Description:
Fixes #1932. Related to #1940.

There’s an earlier pass in #1940. This keeps the fix smaller: `utils.Validate` and `ValidateWithPaths` can be given the required rule objects when validating a generated composite rule, and the config template writes `RequiredRules` as `[[rules.required]]`.

That covers both places a generated composite rule needs support: local rule validation and the generated TOML.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

Tested:

* `go test ./...`
* `go test ./cmd/generate/config ./cmd/generate/config/utils ./config ./detect`
* `make config/gitleaks.toml`
* `golangci-lint run ./cmd/generate/config ./cmd/generate/config/utils`
* `git diff --check`

I also ran `make lint`; it reports two existing staticcheck findings outside this change: `config/config.go:491` and `version/version.go:3`.
