### PR TITLE
Honor max target size inside archives

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -92,6 +92,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 		findings, err = detector.DetectSource(
 			cmd.Context(), &sources.File{
 				Content:         os.Stdin,
+				MaxFileSize:     detector.MaxTargetMegaBytes * 1_000_000,
 				MaxArchiveDepth: detector.MaxArchiveDepth,
 			},
 		)
@@ -122,6 +123,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 				Config:          &detector.Config,
 				Remote:          sources.NewRemoteInfoContext(cmd.Context(), scmPlatform, sourcePath),
 				Sema:            detector.Sema,
+				MaxFileSize:     detector.MaxTargetMegaBytes * 1_000_000,
 				MaxArchiveDepth: detector.MaxArchiveDepth,
 			},
 		)

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -83,6 +83,7 @@ func runGit(cmd *cobra.Command, args []string) {
 			Config:          &detector.Config,
 			Remote:          sources.NewRemoteInfoContext(cmd.Context(), scmPlatform, source),
 			Sema:            detector.Sema,
+			MaxFileSize:     detector.MaxTargetMegaBytes * 1_000_000,
 			MaxArchiveDepth: detector.MaxArchiveDepth,
 		},
 	)

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -40,6 +40,7 @@ func runStdIn(cmd *cobra.Command, _ []string) {
 		cmd.Context(),
 		&sources.File{
 			Content:         os.Stdin,
+			MaxFileSize:     detector.MaxTargetMegaBytes * 1_000_000,
 			MaxArchiveDepth: detector.MaxArchiveDepth,
 		},
 	)

--- a/detect/files.go
+++ b/detect/files.go
@@ -69,6 +69,7 @@ func (d *Detector) DetectFiles(scanTargets <-chan sources.ScanTarget) ([]report.
 				Path:            scanTarget.Path,
 				Symlink:         scanTarget.Symlink,
 				Config:          &d.Config,
+				MaxFileSize:     d.MaxTargetMegaBytes * 1_000_000,
 				MaxArchiveDepth: d.MaxArchiveDepth,
 			}
 

--- a/detect/git.go
+++ b/detect/git.go
@@ -24,6 +24,7 @@ func (d *Detector) DetectGit(cmd *sources.GitCmd, remote *RemoteInfo) ([]report.
 			Config:          &d.Config,
 			Remote:          (*sources.RemoteInfo)(remote),
 			Sema:            d.Sema,
+			MaxFileSize:     d.MaxTargetMegaBytes * 1_000_000,
 			MaxArchiveDepth: d.MaxArchiveDepth,
 		},
 	)

--- a/detect/reader.go
+++ b/detect/reader.go
@@ -16,6 +16,7 @@ func (d *Detector) DetectReader(r io.Reader, bufSize int) ([]report.Finding, err
 	file := sources.File{
 		Content:         r,
 		Buffer:          make([]byte, 1000*bufSize),
+		MaxFileSize:     d.MaxTargetMegaBytes * 1_000_000,
 		MaxArchiveDepth: d.MaxArchiveDepth,
 	}
 
@@ -79,6 +80,7 @@ func (d *Detector) StreamDetectReader(r io.Reader, bufSize int) (<-chan report.F
 	file := sources.File{
 		Content:         r,
 		Buffer:          make([]byte, 1000*bufSize),
+		MaxFileSize:     d.MaxTargetMegaBytes * 1_000_000,
 		MaxArchiveDepth: d.MaxArchiveDepth,
 	}
 

--- a/sources/file.go
+++ b/sources/file.go
@@ -39,6 +39,8 @@ type File struct {
 	// Config is the gitleaks config used for shouldSkipPath. If not set, then
 	// shouldSkipPath is ignored
 	Config *config.Config
+	// MaxFileSize is the largest file size, in bytes, that will be scanned.
+	MaxFileSize int
 	// outerPaths is the list of container paths (e.g. archives) that lead to
 	// this file
 	outerPaths []string
@@ -116,27 +118,38 @@ func (s *File) extractorFragments(ctx context.Context, extractor archives.Extrac
 			return nil
 		}
 
-		innerReader, err := d.Open()
-		if err != nil {
-			logging.Error().Err(err).Str("path", s.FullPath()).Msg("could not open archive inner file")
-			return nil
-		}
-		defer innerReader.Close()
 		path := filepath.Clean(d.NameInArchive)
+		file := &File{
+			Path:            path,
+			Symlink:         s.Symlink,
+			outerPaths:      append(s.outerPaths, filepath.ToSlash(s.Path)),
+			MaxArchiveDepth: s.MaxArchiveDepth,
+			MaxFileSize:     s.MaxFileSize,
+			archiveDepth:    s.archiveDepth + 1,
+		}
 
 		if s.Config != nil && shouldSkipPath(s.Config, path) {
 			logging.Debug().Str("path", s.FullPath()).Msg("skipping file: global allowlist")
 			return nil
 		}
 
-		file := &File{
-			Content:         innerReader,
-			Path:            path,
-			Symlink:         s.Symlink,
-			outerPaths:      append(s.outerPaths, filepath.ToSlash(s.Path)),
-			MaxArchiveDepth: s.MaxArchiveDepth,
-			archiveDepth:    s.archiveDepth + 1,
+		if s.MaxFileSize > 0 && d.Size() > int64(s.MaxFileSize) {
+			logging.Warn().
+				Str("path", file.FullPath()).
+				Msgf(
+					"skipping file: too large max_size=%dMB, size=%dMB",
+					s.MaxFileSize/1_000_000, d.Size()/1_000_000,
+				)
+			return nil
 		}
+
+		innerReader, err := d.Open()
+		if err != nil {
+			logging.Error().Err(err).Str("path", s.FullPath()).Msg("could not open archive inner file")
+			return nil
+		}
+		defer innerReader.Close()
+		file.Content = innerReader
 
 		if err := file.Fragments(ctx, yield); err != nil {
 			return err
@@ -154,7 +167,31 @@ func (s *File) decompressorFragments(ctx context.Context, decompressor archives.
 		return nil
 	}
 
-	if err := s.fileFragments(ctx, bufio.NewReader(innerReader), yield); err != nil {
+	content := io.Reader(innerReader)
+	if s.MaxFileSize > 0 {
+		limited := bytes.Buffer{}
+		n, err := io.CopyN(&limited, innerReader, int64(s.MaxFileSize)+1)
+		if err != nil && err != io.EOF {
+			_ = innerReader.Close()
+			return yield(
+				Fragment{FilePath: s.FullPath()},
+				fmt.Errorf("could not read compressed file: %w", err),
+			)
+		}
+		if n > int64(s.MaxFileSize) {
+			logging.Warn().
+				Str("path", s.FullPath()).
+				Msgf(
+					"skipping file: too large max_size=%dMB, size>%dMB",
+					s.MaxFileSize/1_000_000, s.MaxFileSize/1_000_000,
+				)
+			_ = innerReader.Close()
+			return nil
+		}
+		content = &limited
+	}
+
+	if err := s.fileFragments(ctx, bufio.NewReader(content), yield); err != nil {
 		_ = innerReader.Close()
 		return err
 	}

--- a/sources/file_test.go
+++ b/sources/file_test.go
@@ -1,0 +1,93 @@
+package sources
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fatih/semgroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveMemberHonorsMaxFileSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "large.zip")
+	require.NoError(t, writeZipFile(archivePath, "large.txt", bytes.Repeat([]byte("A"), 2_000)))
+
+	source := Files{
+		Path:            archivePath,
+		Sema:            semgroup.NewGroup(context.Background(), 1),
+		MaxArchiveDepth: 1,
+		MaxFileSize:     1_000,
+	}
+
+	var fragments []Fragment
+	err := source.Fragments(context.Background(), func(fragment Fragment, err error) error {
+		require.NoError(t, err)
+		fragments = append(fragments, fragment)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, fragments)
+}
+
+func TestCompressedFileHonorsMaxFileSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	gzipPath := filepath.Join(tmpDir, "large.txt.gz")
+	require.NoError(t, writeGzipFile(gzipPath, bytes.Repeat([]byte("A"), 2_000)))
+
+	source := Files{
+		Path:            gzipPath,
+		Sema:            semgroup.NewGroup(context.Background(), 1),
+		MaxArchiveDepth: 1,
+		MaxFileSize:     1_000,
+	}
+
+	var fragments []Fragment
+	err := source.Fragments(context.Background(), func(fragment Fragment, err error) error {
+		require.NoError(t, err)
+		fragments = append(fragments, fragment)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, fragments)
+}
+
+func writeZipFile(path, name string, content []byte) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	w, err := zw.Create(name)
+	if err != nil {
+		_ = zw.Close()
+		return err
+	}
+	if _, err := w.Write(content); err != nil {
+		_ = zw.Close()
+		return err
+	}
+	return zw.Close()
+}
+
+func writeGzipFile(path string, content []byte) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	if _, err := gw.Write(content); err != nil {
+		_ = gw.Close()
+		return err
+	}
+	return gw.Close()
+}

--- a/sources/files.go
+++ b/sources/files.go
@@ -167,6 +167,7 @@ func (s *Files) Fragments(ctx context.Context, yield FragmentsFunc) error {
 					Path:            scanTarget.Path,
 					Symlink:         scanTarget.Symlink,
 					Config:          s.Config,
+					MaxFileSize:     s.MaxFileSize,
 					MaxArchiveDepth: s.MaxArchiveDepth,
 				}
 

--- a/sources/git.go
+++ b/sources/git.go
@@ -282,6 +282,7 @@ type Git struct {
 	Config          *config.Config
 	Remote          *RemoteInfo
 	Sema            *semgroup.Group
+	MaxFileSize     int
 	MaxArchiveDepth int
 }
 
@@ -372,6 +373,7 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 					file := File{
 						Content:         blob,
 						Path:            gitdiffFile.NewName,
+						MaxFileSize:     s.MaxFileSize,
 						MaxArchiveDepth: s.MaxArchiveDepth,
 						Config:          s.Config,
 					}


### PR DESCRIPTION
### Description:
`--max-target-megabytes` was applied before regular files reached `sources.File`, but archive contents did not carry that limit. A small zip could contain a larger member and still get scanned; gzip streams had the same problem after decompression.

This passes the byte limit through file and git sources, skips oversized archive entries before opening them when the entry size is known, and reads at most `MaxFileSize + 1` bytes from decompressed streams before scanning.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

Tests:
- `go test ./...`
- `golangci-lint run ./sources/... ./detect/... ./cmd/...`

`make lint` still reports two existing staticcheck items outside this patch (`config/config.go` and `version/version.go`).