### PR TITLE
feat: Add secret-value support to .gitleaksignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,20 @@ class CustomClass:
 
 #### .gitleaksignore
 
-You can ignore specific findings by creating a `.gitleaksignore` file at the root of your repo. In release v8.10.0 Gitleaks added a `Fingerprint` value to the Gitleaks report. Each leak, or finding, has a Fingerprint that uniquely identifies a secret. Add this fingerprint to the `.gitleaksignore` file to ignore that specific secret. See Gitleaks' [.gitleaksignore](https://github.com/gitleaks/gitleaks/blob/master/.gitleaksignore) for an example. Note: this feature is experimental and is subject to change in the future.
+You can ignore specific findings by creating a `.gitleaksignore` file at the root of your repo. In release v8.10.0 Gitleaks added a `Fingerprint` value to the Gitleaks report. Each leak, or finding, has a Fingerprint that uniquely identifies a secret. Add this fingerprint to the `.gitleaksignore` file to ignore that specific secret.
+
+`.gitleaksignore` also supports ignoring by the extracted `Secret` value in a finding. This matches the exact `finding.Secret` value that Gitleaks reports, not the full `Match` or the raw source text. For decoded findings, this means the ignored value may be the decoded secret. If you want to copy the exact secret value into `.gitleaksignore`, you may need unredacted report output.
+
+Supported secret ignore entries:
+
+```ini
+secret:AKIALALEMEL33243OLIA
+rule:aws-access-key:secret:AKIALALEMEL33243OLIA
+path:cmd/generate/config/rules/aws.go:secret:AKIALALEMEL33243OLIA
+path:cmd/generate/config/rules/aws.go:rule:aws-access-key:secret:AKIALALEMEL33243OLIA
+```
+
+See Gitleaks' [.gitleaksignore](https://github.com/gitleaks/gitleaks/blob/master/.gitleaksignore) for an example. Note: this feature is experimental and is subject to change in the future.
 
 #### Decoding
 

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -35,6 +35,12 @@ var (
 	newLineRegexp = regexp.MustCompile("\n")
 )
 
+type gitleaksIgnoreSecret struct {
+	Path   string
+	RuleID string
+	Secret string
+}
+
 // Detector is the main detector struct
 type Detector struct {
 	// Config is the configuration for the detector
@@ -96,6 +102,9 @@ type Detector struct {
 	// gitleaksIgnore
 	gitleaksIgnore map[string]struct{}
 
+	// gitleaksIgnoreSecrets
+	gitleaksIgnoreSecrets map[string][]gitleaksIgnoreSecret
+
 	// Sema (https://github.com/fatih/semgroup) controls the concurrency
 	Sema *semgroup.Group
 
@@ -120,14 +129,15 @@ func NewDetector(cfg config.Config) *Detector {
 // context to use for timeouts
 func NewDetectorContext(ctx context.Context, cfg config.Config) *Detector {
 	return &Detector{
-		commitMap:      make(map[string]bool),
-		gitleaksIgnore: make(map[string]struct{}),
-		findingMutex:   &sync.Mutex{},
-		commitMutex:    &sync.Mutex{},
-		findings:       make([]report.Finding, 0),
-		Config:         cfg,
-		prefilter:      *ahocorasick.NewTrieBuilder().AddStrings(maps.Keys(cfg.Keywords)).Build(),
-		Sema:           semgroup.NewGroup(ctx, 40),
+		commitMap:             make(map[string]bool),
+		gitleaksIgnore:        make(map[string]struct{}),
+		gitleaksIgnoreSecrets: make(map[string][]gitleaksIgnoreSecret),
+		findingMutex:          &sync.Mutex{},
+		commitMutex:           &sync.Mutex{},
+		findings:              make([]report.Finding, 0),
+		Config:                cfg,
+		prefilter:             *ahocorasick.NewTrieBuilder().AddStrings(maps.Keys(cfg.Keywords)).Build(),
+		Sema:                  semgroup.NewGroup(ctx, 40),
 	}
 }
 
@@ -164,11 +174,20 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 	}()
 
 	scanner := bufio.NewScanner(file)
-	replacer := strings.NewReplacer("\\", "/")
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		// Skip lines that start with a comment
 		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if isSecretIgnore(line) {
+			secretIgnore, err := parseGitleaksIgnoreSecret(line)
+			if err != nil {
+				logging.Warn().Err(err).Str("entry", line).Msg("Invalid .gitleaksignore secret entry")
+				continue
+			}
+			d.gitleaksIgnoreSecrets[secretIgnore.Secret] = append(d.gitleaksIgnoreSecrets[secretIgnore.Secret], *secretIgnore)
 			continue
 		}
 
@@ -179,17 +198,67 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 		case 3:
 			// Global fingerprint.
 			// `file:rule-id:start-line`
-			s[0] = replacer.Replace(s[0])
+			s[0] = normalizeGitleaksIgnorePath(s[0])
 		case 4:
 			// Commit fingerprint.
 			// `commit:file:rule-id:start-line`
-			s[1] = replacer.Replace(s[1])
+			s[1] = normalizeGitleaksIgnorePath(s[1])
 		default:
 			logging.Warn().Str("fingerprint", line).Msg("Invalid .gitleaksignore entry")
 		}
 		d.gitleaksIgnore[strings.Join(s, ":")] = struct{}{}
 	}
 	return nil
+}
+
+func isSecretIgnore(line string) bool {
+	return strings.HasPrefix(line, "secret:") ||
+		strings.HasPrefix(line, "rule:") ||
+		strings.HasPrefix(line, "path:")
+}
+
+func parseGitleaksIgnoreSecret(line string) (*gitleaksIgnoreSecret, error) {
+	var secretIgnore gitleaksIgnoreSecret
+
+	if strings.HasPrefix(line, "path:") {
+		var ok bool
+		secretIgnore.Path, line, ok = cutGitleaksIgnoreSegment(strings.TrimPrefix(line, "path:"))
+		if !ok {
+			return nil, fmt.Errorf("missing path segment")
+		}
+		secretIgnore.Path = normalizeGitleaksIgnorePath(secretIgnore.Path)
+	}
+
+	if strings.HasPrefix(line, "rule:") {
+		var ok bool
+		secretIgnore.RuleID, line, ok = cutGitleaksIgnoreSegment(strings.TrimPrefix(line, "rule:"))
+		if !ok {
+			return nil, fmt.Errorf("missing rule segment")
+		}
+	}
+
+	if !strings.HasPrefix(line, "secret:") {
+		return nil, fmt.Errorf("missing secret segment")
+	}
+
+	secretIgnore.Secret = strings.TrimPrefix(line, "secret:")
+	if secretIgnore.Secret == "" {
+		return nil, fmt.Errorf("missing secret value")
+	}
+
+	return &secretIgnore, nil
+}
+
+func cutGitleaksIgnoreSegment(line string) (segment string, rest string, ok bool) {
+	idx := strings.Index(line, ":")
+	if idx <= 0 {
+		return "", "", false
+	}
+	return line[:idx], line[idx+1:], true
+}
+
+func normalizeGitleaksIgnorePath(path string) string {
+	return strings.ReplaceAll(path, "\\", "/")
 }
 
 // DetectBytes scans the given bytes and returns a list of findings
@@ -246,7 +315,7 @@ func (d *Detector) DetectSource(ctx context.Context, source sources.Source) ([]r
 			})
 		}
 
-		for _, finding := range d.DetectContext(ctx, Fragment(fragment)) {
+		for _, finding := range d.detect(ctx, Fragment(fragment), 0) {
 			d.AddFinding(finding)
 		}
 
@@ -274,6 +343,10 @@ func (d *Detector) Detect(fragment Fragment) []report.Finding {
 // DetectContext is the same as Detect but supports passing in a
 // context to use for timeouts
 func (d *Detector) DetectContext(ctx context.Context, fragment Fragment) []report.Finding {
+	return d.detect(ctx, fragment, d.Redact)
+}
+
+func (d *Detector) detect(ctx context.Context, fragment Fragment, redact uint) []report.Finding {
 	if fragment.Bytes == nil {
 		d.TotalBytes.Add(uint64(len(fragment.Raw)))
 	}
@@ -364,7 +437,7 @@ ScanLoop:
 		}
 	}
 
-	return filter(findings, d.Redact)
+	return filter(findings, redact)
 }
 
 // detectRule scans the given fragment for the given rule and returns a list of findings
@@ -732,12 +805,19 @@ func (d *Detector) AddFinding(finding report.Finding) {
 			return
 		}
 	}
+	if d.isSecretIgnored(finding) {
+		logger.Debug().Msg("skipping finding: secret ignore")
+		return
+	}
 
 	if d.baseline != nil && !IsNew(finding, d.Redact, d.baseline) {
 		logger.Debug().
 			Str("fingerprint", finding.Fingerprint).
 			Msgf("skipping finding: baseline")
 		return
+	}
+	if d.Redact > 0 {
+		finding.Redact(d.Redact)
 	}
 
 	d.findingMutex.Lock()
@@ -746,6 +826,26 @@ func (d *Detector) AddFinding(finding report.Finding) {
 		printFinding(finding, d.NoColor)
 	}
 	d.findingMutex.Unlock()
+}
+
+func (d *Detector) isSecretIgnored(finding report.Finding) bool {
+	secretIgnores := d.gitleaksIgnoreSecrets[finding.Secret]
+	if len(secretIgnores) == 0 {
+		return false
+	}
+
+	filePath := normalizeGitleaksIgnorePath(finding.File)
+	for _, secretIgnore := range secretIgnores {
+		if secretIgnore.Path != "" && secretIgnore.Path != filePath {
+			continue
+		}
+		if secretIgnore.RuleID != "" && secretIgnore.RuleID != finding.RuleID {
+			continue
+		}
+		return true
+	}
+
+	return false
 }
 
 // Findings returns the findings added to the detector

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -2457,6 +2457,269 @@ func moveDotGit(t *testing.T, from, to string) {
 	}
 }
 
+func TestParseGitleaksIgnoreSecret(t *testing.T) {
+	tests := map[string]struct {
+		line    string
+		want    *gitleaksIgnoreSecret
+		wantErr bool
+	}{
+		"secret only": {
+			line: "secret:AKIALALEMEL33243OLIA",
+			want: &gitleaksIgnoreSecret{
+				Secret: "AKIALALEMEL33243OLIA",
+			},
+		},
+		"rule and secret": {
+			line: "rule:aws-access-key:secret:AKIALALEMEL33243OLIA",
+			want: &gitleaksIgnoreSecret{
+				RuleID: "aws-access-key",
+				Secret: "AKIALALEMEL33243OLIA",
+			},
+		},
+		"path and secret": {
+			line: "path:foo\\bar\\main.go:secret:AKIALALEMEL33243OLIA",
+			want: &gitleaksIgnoreSecret{
+				Path:   "foo/bar/main.go",
+				Secret: "AKIALALEMEL33243OLIA",
+			},
+		},
+		"path rule and secret": {
+			line: "path:foo/bar/main.go:rule:aws-access-key:secret:AKIALALEMEL33243OLIA",
+			want: &gitleaksIgnoreSecret{
+				Path:   "foo/bar/main.go",
+				RuleID: "aws-access-key",
+				Secret: "AKIALALEMEL33243OLIA",
+			},
+		},
+		"secret with colons": {
+			line: "secret:user:pass:token",
+			want: &gitleaksIgnoreSecret{
+				Secret: "user:pass:token",
+			},
+		},
+		"missing secret value": {
+			line:    "secret:",
+			wantErr: true,
+		},
+		"invalid order": {
+			line:    "rule:aws-access-key:path:foo/bar/main.go:secret:AKIALALEMEL33243OLIA",
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseGitleaksIgnoreSecret(tt.line)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAddFindingGitleaksIgnoreSecret(t *testing.T) {
+	tests := map[string]struct {
+		secretIgnores []gitleaksIgnoreSecret
+		finding       report.Finding
+		wantFindings  int
+	}{
+		"secret only": {
+			secretIgnores: []gitleaksIgnoreSecret{{
+				Secret: "AKIALALEMEL33243OLIA",
+			}},
+			finding: report.Finding{
+				RuleID:    "aws-access-key",
+				Secret:    "AKIALALEMEL33243OLIA",
+				File:      "foo/main.go",
+				StartLine: 20,
+			},
+		},
+		"path exact match": {
+			secretIgnores: []gitleaksIgnoreSecret{{
+				Path:   "foo/bar/main.go",
+				Secret: "AKIALALEMEL33243OLIA",
+			}},
+			finding: report.Finding{
+				RuleID:    "aws-access-key",
+				Secret:    "AKIALALEMEL33243OLIA",
+				File:      "foo/bar/main.go",
+				StartLine: 20,
+			},
+		},
+		"path normalized match": {
+			secretIgnores: []gitleaksIgnoreSecret{{
+				Path:   "foo/bar/main.go",
+				Secret: "AKIALALEMEL33243OLIA",
+			}},
+			finding: report.Finding{
+				RuleID:    "aws-access-key",
+				Secret:    "AKIALALEMEL33243OLIA",
+				File:      "foo\\bar\\main.go",
+				StartLine: 20,
+			},
+		},
+		"path mismatch": {
+			secretIgnores: []gitleaksIgnoreSecret{{
+				Path:   "foo/bar/main.go",
+				Secret: "AKIALALEMEL33243OLIA",
+			}},
+			finding: report.Finding{
+				RuleID:    "aws-access-key",
+				Secret:    "AKIALALEMEL33243OLIA",
+				File:      "foo/other.go",
+				StartLine: 20,
+			},
+			wantFindings: 1,
+		},
+		"rule match": {
+			secretIgnores: []gitleaksIgnoreSecret{{
+				RuleID: "aws-access-key",
+				Secret: "AKIALALEMEL33243OLIA",
+			}},
+			finding: report.Finding{
+				RuleID:    "aws-access-key",
+				Secret:    "AKIALALEMEL33243OLIA",
+				File:      "foo/main.go",
+				StartLine: 20,
+			},
+		},
+		"rule mismatch": {
+			secretIgnores: []gitleaksIgnoreSecret{{
+				RuleID: "aws-access-key",
+				Secret: "AKIALALEMEL33243OLIA",
+			}},
+			finding: report.Finding{
+				RuleID:    "generic-api-key",
+				Secret:    "AKIALALEMEL33243OLIA",
+				File:      "foo/main.go",
+				StartLine: 20,
+			},
+			wantFindings: 1,
+		},
+		"path and rule both match": {
+			secretIgnores: []gitleaksIgnoreSecret{{
+				Path:   "foo/bar/main.go",
+				RuleID: "aws-access-key",
+				Secret: "AKIALALEMEL33243OLIA",
+			}},
+			finding: report.Finding{
+				RuleID:    "aws-access-key",
+				Secret:    "AKIALALEMEL33243OLIA",
+				File:      "foo/bar/main.go",
+				StartLine: 20,
+			},
+		},
+		"path and rule mismatch": {
+			secretIgnores: []gitleaksIgnoreSecret{{
+				Path:   "foo/bar/main.go",
+				RuleID: "aws-access-key",
+				Secret: "AKIALALEMEL33243OLIA",
+			}},
+			finding: report.Finding{
+				RuleID:    "generic-api-key",
+				Secret:    "AKIALALEMEL33243OLIA",
+				File:      "foo/bar/main.go",
+				StartLine: 20,
+			},
+			wantFindings: 1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := NewDetector(config.Config{})
+			for _, secretIgnore := range tt.secretIgnores {
+				d.gitleaksIgnoreSecrets[secretIgnore.Secret] = append(d.gitleaksIgnoreSecrets[secretIgnore.Secret], secretIgnore)
+			}
+
+			d.AddFinding(tt.finding)
+
+			assert.Len(t, d.Findings(), tt.wantFindings)
+		})
+	}
+}
+
+func TestDecodedSecretGitleaksIgnore(t *testing.T) {
+	viper.Reset()
+	viper.AddConfigPath(configPath)
+	viper.SetConfigName("encoded")
+	viper.SetConfigType("toml")
+	err := viper.ReadInConfig()
+	require.NoError(t, err)
+
+	var vc config.ViperConfig
+	err = viper.Unmarshal(&vc)
+	require.NoError(t, err)
+	cfg, err := vc.Translate()
+	require.NoError(t, err)
+
+	d := NewDetector(cfg)
+	d.MaxDecodeDepth = maxDecodeDepth
+
+	dir := t.TempDir()
+	ignorePath := filepath.Join(dir, ".gitleaksignore")
+	err = os.WriteFile(ignorePath, []byte("secret:lRqBK-z5kf4-please-ignore-me-X-XIJM2Pddw\n"), 0o600)
+	require.NoError(t, err)
+	err = d.AddGitleaksIgnore(ignorePath)
+	require.NoError(t, err)
+
+	findings := d.Detect(Fragment{
+		Raw:      "password=\"bFJxQkstejVrZjQtcGxlYXNlLWlnbm9yZS1tZS1YLVhJSk0yUGRkdw==\"",
+		FilePath: "tmp.go",
+	})
+	require.Len(t, findings, 1)
+	assert.Equal(t, "decoded-password-dont-ignore", findings[0].RuleID)
+	assert.Equal(t, "lRqBK-z5kf4-please-ignore-me-X-XIJM2Pddw", findings[0].Secret)
+
+	for _, finding := range findings {
+		d.AddFinding(finding)
+	}
+
+	assert.Empty(t, d.Findings())
+}
+
+func TestDecodedSecretGitleaksIgnoreWithRedaction(t *testing.T) {
+	viper.Reset()
+	viper.AddConfigPath(configPath)
+	viper.SetConfigName("encoded")
+	viper.SetConfigType("toml")
+	err := viper.ReadInConfig()
+	require.NoError(t, err)
+
+	var vc config.ViperConfig
+	err = viper.Unmarshal(&vc)
+	require.NoError(t, err)
+	cfg, err := vc.Translate()
+	require.NoError(t, err)
+
+	d := NewDetector(cfg)
+	d.MaxDecodeDepth = maxDecodeDepth
+	d.Redact = 100
+
+	dir := t.TempDir()
+	ignorePath := filepath.Join(dir, ".gitleaksignore")
+	err = os.WriteFile(ignorePath, []byte("secret:lRqBK-z5kf4-please-ignore-me-X-XIJM2Pddw\n"), 0o600)
+	require.NoError(t, err)
+	err = d.AddGitleaksIgnore(ignorePath)
+	require.NoError(t, err)
+
+	source := sources.File{
+		Content: strings.NewReader("password=\"bFJxQkstejVrZjQtcGxlYXNlLWlnbm9yZS1tZS1YLVhJSk0yUGRkdw==\""),
+		Path:    "tmp.go",
+		Config:  &cfg,
+	}
+
+	findings, err := d.DetectSource(context.Background(), &source)
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+	assert.Empty(t, d.Findings())
+}
+
 // region Windows-specific tests[]
 func TestNormalizeGitleaksIgnorePaths(t *testing.T) {
 	d, err := NewDetectorDefaultConfig()

--- a/detect/files.go
+++ b/detect/files.go
@@ -79,7 +79,7 @@ func (d *Detector) DetectFiles(scanTargets <-chan sources.ScanTarget) ([]report.
 					return nil
 				}
 
-				for _, finding := range d.Detect(Fragment(fragment)) {
+				for _, finding := range d.detect(ctx, Fragment(fragment), 0) {
 					d.AddFinding(finding)
 				}
 				return nil


### PR DESCRIPTION
### Description:

This PR adds support for secret-value based entries in `.gitleaksignore` alongside the existing fingerprint-based format.

Today `.gitleaksignore` only supports fingerprints. That makes ignores brittle when a file changes but the same false positive remains present. This change adds a more stable ignore mechanism by allowing users to ignore findings by exact extracted `finding.Secret` value, with optional `path` and/or `rule` scoping to reduce blast radius.

Supported entry formats:

- `secret:<value>`
- `rule:<rule-id>:secret:<value>`
- `path:<normalized-path>:secret:<value>`
- `path:<normalized-path>:rule:<rule-id>:secret:<value>`

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

