### PR TITLE
build: update Go toolchain for CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zricethezav/gitleaks/v8
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/BobuSumisu/aho-corasick v1.0.3


### PR DESCRIPTION
### Description:
Bump the module Go directive from `1.24.11` to `1.24.13` so future release builds require a patched Go 1.24 stdlib.

Trivy reported the released Linux binary from `v8.30.1`, installed at `mise/installs/gitleaks/8.30.1/gitleaks`, as a Go binary affected by stdlib [CVE-2025-68121](https://nvd.nist.gov/vuln/detail/cve-2025-68121) with CRITICAL severity. The binary appears to have been built with Go `v1.24.11`. Trivy lists the fixed Go stdlib versions as `1.24.13`, `1.25.7`, and `1.26.0-rc.3`.

Validation run locally:

* `go version` -> `go1.25.9 darwin/arm64`
* `go build ./...`
* `go test ./...`
* `go test -race ./...`
* `go generate ./...`
* `git diff --exit-code -- ':!go.mod'`

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes? Not applicable for this toolchain metadata update.
* [ ] Have you lint your code locally prior to submission? Not applicable; no code changes.