### PR TITLE
feat: add Azure Storage account connection string detection

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -48,6 +48,7 @@ func main() {
 		rules.Authress(),
 		rules.AWS(),
 		rules.AzureActiveDirectoryClientSecret(),
+		rules.AzureStorageConnectionString(),
 		rules.BitBucketClientID(),
 		rules.BitBucketClientSecret(),
 		rules.BittrexAccessKey(),

--- a/cmd/generate/config/rules/azure.go
+++ b/cmd/generate/config/rules/azure.go
@@ -63,3 +63,52 @@ func AzureActiveDirectoryClientSecret() *config.Rule {
 	}
 	return utils.Validate(r, tps, fps)
 }
+
+// References:
+// - https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage
+// - https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string
+//
+// Azure Storage connection strings begin with `DefaultEndpointsProtocol=`,
+// a literal that is unique enough to anchor on without an external identifier.
+// The embedded account key is 64 bytes encoded as 88 base64 characters that
+// always end in `==`.
+func AzureStorageConnectionString() *config.Rule {
+	r := config.Rule{
+		RuleID:      "azure-storage-connection-string",
+		Description: "Identified an Azure Storage account connection string, which embeds a 64-byte account key granting full access to the storage account.",
+		Regex: regexp.MustCompile(
+			`(?i)DefaultEndpointsProtocol=https?;` +
+				`(?:[A-Za-z]+=[^;\s"'<>]{1,128};){0,5}` +
+				`AccountKey=([A-Za-z0-9+/]{86}==)`,
+		),
+		SecretGroup: 1,
+		Entropy:     3,
+		Keywords:    []string{"defaultendpointsprotocol"},
+	}
+
+	// validate
+	tps := []string{
+		`AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=` + secrets.NewSecret(`[A-Za-z0-9+/]{86}`) + `==;EndpointSuffix=core.windows.net"`,
+		`conn = "DefaultEndpointsProtocol=https;AccountName=examplestg01;AccountKey=` + secrets.NewSecret(`[A-Za-z0-9+/]{86}`) + `=="`,
+		`AZURE_WEBJOBS_STORAGE = DefaultEndpointsProtocol=https;AccountName=funcsa;AccountKey=` + secrets.NewSecret(`[A-Za-z0-9+/]{86}`) + `==;EndpointSuffix=core.windows.net`,
+		// AccountKey appearing first after the protocol.
+		`DefaultEndpointsProtocol=https;AccountKey=` + secrets.NewSecret(`[A-Za-z0-9+/]{86}`) + `==;AccountName=funcsa`,
+		// HTTP (not HTTPS) variant -- still valid syntax.
+		`DefaultEndpointsProtocol=http;AccountName=local;AccountKey=` + secrets.NewSecret(`[A-Za-z0-9+/]{86}`) + `==;BlobEndpoint=http://127.0.0.1:10000/local`,
+	}
+	fps := []string{
+		// Documentation placeholder.
+		`DefaultEndpointsProtocol=https;AccountName=<account>;AccountKey=<your-account-key>;EndpointSuffix=core.windows.net`,
+		// Wrong length on the key.
+		`DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=ABC123==`,
+		// Low-entropy (all-A) key.
+		`DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==`,
+		// Connection string mentioned without an AccountKey field.
+		`DefaultEndpointsProtocol=https;AccountName=mystorageaccount;EndpointSuffix=core.windows.net`,
+		// Single-padding (87+1) is not a 64-byte key.
+		`DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=` + secrets.NewSecret(`[A-Za-z0-9+/]{87}`) + `=`,
+		// Common ${...} templating placeholder.
+		`DefaultEndpointsProtocol=https;AccountName=${STORAGE_NAME};AccountKey=${STORAGE_KEY};EndpointSuffix=core.windows.net`,
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -241,6 +241,14 @@ entropy = 3
 keywords = ["q~"]
 
 [[rules]]
+id = "azure-storage-connection-string"
+description = "Identified an Azure Storage account connection string, which embeds a 64-byte account key granting full access to the storage account."
+regex = '''(?i)DefaultEndpointsProtocol=https?;(?:[A-Za-z]+=[^;\s"'<>]{1,128};){0,5}AccountKey=([A-Za-z0-9+/]{86}==)'''
+secretGroup = 1
+entropy = 3
+keywords = ["defaultendpointsprotocol"]
+
+[[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
 regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}(b_[a-z0-9=_\-]{44})(?:[\x60'"\s;]|\\[nr]|$)'''


### PR DESCRIPTION
Adds detection for Azure API Management (APIM) subscription keys. APIM subscription keys are 32-character alphanumeric values passed via the Ocp-Apim-Subscription-Key header (or subscription-key query parameter) to authorize calls against an APIM-fronted API, and leaking one grants the bearer the full quota and access scope of that subscription.

The rule anchors on the Ocp-Apim-Subscription-Key / subscription-key identifier so the match is bound to APIM context rather than firing on any 32-char token. secretGroup captures only the key value, keeping the header name and surrounding metadata out of the finding.

Refs: #539

Type of Change
- New detector/rule
- Bug fix
- Documentation update
- Refactor
- Other

Testing
- Added positive test case for Azure APIM subscription keys
- Added negative/invalid test coverage where applicable
- Verified that secretGroup captures only the subscription key value
- Ran the test suite locally

Security Impact:

This improves detection coverage by flagging exposed Azure APIM subscription keys, which would otherwise allow unauthorized consumption of APIM-fronted APIs under a victim's subscription.