### PR TITLE
chore: bump Go to 1.26.3 to fix vulnerabilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
-          go-version: 1.25
+          go-version: 1.26.3
 
       - name: Build
         run: go build ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS build
+FROM golang:1.26 AS build
 WORKDIR /go/src/github.com/zricethezav/gitleaks
 COPY . .
 RUN VERSION=$(git describe --tags --abbrev=0) && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zricethezav/gitleaks/v8
 
-go 1.24.11
+go 1.26.3
 
 require (
 	github.com/BobuSumisu/aho-corasick v1.0.3


### PR DESCRIPTION
### Description:
The version bump will fix a couple of vulnerabilities, such as:
 https://www.cvedetails.com/cve/CVE-2026-27143/
 https://www.cvedetails.com/cve/CVE-2026-27140/
 https://www.cvedetails.com/cve/CVE-2025-68121/
 
I tested everything locally with both the Mac and Windows binaries, alongside the Go 1.24.11 binaries, and everything was aligned.
I would really appreciate it if we could make this change happen.
 

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
