### PR TITLE
Add Mercado Pago access token and public key detection rules

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -3207,3 +3207,15 @@ description = "Detected a Zendesk Secret Key, risking unauthorized access to cus
 regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{40})(?:[\x60'"\s;]|\\[nr]|$)'''
 keywords = ["zendesk"]
 
+[[rules]]
+id = "mercadopago-access-token"
+description = "Detected a Mercado Pago Access Token, which could allow unauthorized access to payment processing and financial transactions."
+regex = '''\b((?:APP_USR|TEST)-\d{10,20}-\d{6}-[a-zA-Z0-9]{10,40}-\d{5,12})\b'''
+entropy = 3.5
+keywords = ["app_usr", "test-"]
+
+[[rules]]
+id = "mercadopago-public-key"
+description = "Detected a Mercado Pago Public Key, which could expose payment integration credentials."
+regex = '''\b(APP_USR-[a-f0-9]{8}-[A-Z0-9]{6}-[a-f0-9]{12})\b'''
+keywords = ["app_usr"]


### PR DESCRIPTION
## Summary

Added two new detection rules for Mercado Pago credentials, one of the 
largest payment processors in Latin America (200M+ users).

## Rules added

- `mercadopago-access-token`: Detects both production (APP_USR-) and 
  test (TEST-) access tokens used to authenticate Mercado Pago API requests
- `mercadopago-public-key`: Detects Mercado Pago public keys used in 
  payment integrations

## Token format

Mercado Pago tokens follow a distinctive pattern:
`APP_USR-{appID}-{MMDDYY}-{hash}-{userID}`

## Test results

- ✅ APP_USR production token detected
- ✅ TEST sandbox token detected  
- ✅ Public key detected
- ✅ Generic bearer tokens not flagged (no false positives)

## References

- https://www.mercadopago.com.br/developers/en/docs/your-integrations/credentials
- https://www.mercadopago.com.br/developers/en/reference/authentication/oauth/_oauth_token/post