### PR TITLE
withinProximity: require same line for withinColumns to apply

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -687,9 +687,13 @@ func (d *Detector) withinProximity(primary, required report.Finding, requiredRul
 		}
 	}
 
-	// Check column proximity (horizontal distance)
+	// Check column proximity (horizontal distance). Columns restart at
+	// every newline, so comparing them across different lines is
+	// meaningless - treat that as out of range.
 	if requiredRule.WithinColumns != nil {
-		// Use the start column of each finding for proximity calculation
+		if primary.StartLine != required.StartLine {
+			return false
+		}
 		colDiff := abs(primary.StartColumn - required.StartColumn)
 		if colDiff > *requiredRule.WithinColumns {
 			return false

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -2771,3 +2771,25 @@ func TestWindowsFileSeparator_RuleAllowlistPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestWithinProximityColumnsRequireSameLine(t *testing.T) {
+	// Regression for #2122: column proximity has no meaning across
+	// different lines, since columns restart at each newline.
+	d := &Detector{}
+	cols := 5
+	required := &config.Required{WithinColumns: &cols}
+	primary := report.Finding{StartLine: 1, StartColumn: 5}
+	otherLine := report.Finding{StartLine: 300, StartColumn: 6}
+	sameLine := report.Finding{StartLine: 1, StartColumn: 8}
+	farSameLine := report.Finding{StartLine: 1, StartColumn: 60}
+
+	if d.withinProximity(primary, otherLine, required) {
+		t.Error("findings on different lines should fail withinColumns")
+	}
+	if !d.withinProximity(primary, sameLine, required) {
+		t.Error("findings 3 columns apart on the same line should satisfy withinColumns: 5")
+	}
+	if d.withinProximity(primary, farSameLine, required) {
+		t.Error("findings 55 columns apart on the same line should fail withinColumns: 5")
+	}
+}


### PR DESCRIPTION
Closes #2122.

Columns restart at every newline, so subtracting `StartColumn` across findings on different lines produces a meaningless result. Two findings 300 lines apart with similar columns currently pass any `withinColumns` threshold, and two findings 60 columns apart on the same line can still pass `withinColumns: 5` by coincidence of being on different lines.

Treat cross-line findings as out of range so the check matches the same-line proximity the README documents.