### PR TITLE
config: switch the bundled gitleaks.toml to [[allowlists]]

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -18,7 +18,7 @@ title = "{{.Title}}"
 # config-enabled features are guaranteed to work.
 minVersion = "v8.25.0"
 
-{{ with .Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}# TODO: change to [[allowlists]]{{println}}[allowlist]
+{{ with .Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}[[allowlists]]
 {{- with .Description }}{{println}}description = "{{ . }}"{{ end }}
 {{- with .MatchCondition }}{{println}}condition = "{{ .String }}"{{ end }}
 {{- with .Commits -}}{{println}}commits = [

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -18,8 +18,7 @@ title = "gitleaks config"
 # config-enabled features are guaranteed to work.
 minVersion = "v8.25.0"
 
-# TODO: change to [[allowlists]]
-[allowlist]
+[[allowlists]]
 description = "global allow lists"
 paths = [
     '''gitleaks\.toml''',


### PR DESCRIPTION
Closes #2120.

Picks up the `# TODO: change to [[allowlists]]` next to the global block and also updates the config generator template so the next regeneration doesn't reintroduce the deprecated `[allowlist]` form. Both `[allowlist]` and `[[allowlists]]` still parse, but the latter has been the documented shape since v8.25.0.