### PR TITLE
Fix quoted --log-opts parsing

### DIFF
--- a/sources/git.go
+++ b/sources/git.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/fatih/semgroup"
 	"github.com/gitleaks/go-gitdiff/gitdiff"
@@ -22,8 +23,6 @@ import (
 	"github.com/zricethezav/gitleaks/v8/config"
 	"github.com/zricethezav/gitleaks/v8/logging"
 )
-
-var quotedOptPattern = regexp.MustCompile(`^(?:"[^"]+"|'[^']+')$`)
 
 // GitCmd helps to work with Git's output.
 type GitCmd struct {
@@ -73,20 +72,10 @@ func NewGitLogCmdContext(ctx context.Context, source string, logOpts string) (*G
 	var cmd *exec.Cmd
 	if logOpts != "" {
 		args := []string{"-C", sourceClean, "log", "-p", "-U0"}
-
-		// Ensure that the user-provided |logOpts| aren't wrapped in quotes.
-		// https://github.com/gitleaks/gitleaks/issues/1153
-		userArgs := strings.Split(logOpts, " ")
-		var quotedOpts []string
-		for _, element := range userArgs {
-			if quotedOptPattern.MatchString(element) {
-				quotedOpts = append(quotedOpts, element)
-			}
+		userArgs, err := parseLogOpts(logOpts)
+		if err != nil {
+			return nil, err
 		}
-		if len(quotedOpts) > 0 {
-			logging.Warn().Msgf("the following `--log-opts` values may not work as expected: %v\n\tsee https://github.com/gitleaks/gitleaks/issues/1153 for more information", quotedOpts)
-		}
-
 		args = append(args, userArgs...)
 		cmd = exec.CommandContext(ctx, "git", args...)
 	} else {
@@ -169,6 +158,70 @@ func NewGitDiffCmdContext(ctx context.Context, source string, staged bool) (*Git
 		errCh:       errCh,
 		repoPath:    sourceClean,
 	}, nil
+}
+
+func parseLogOpts(logOpts string) ([]string, error) {
+	var (
+		args         []string
+		arg          strings.Builder
+		quote        rune
+		escaped      bool
+		tokenStarted bool
+	)
+
+	flush := func() {
+		if tokenStarted {
+			args = append(args, arg.String())
+			arg.Reset()
+			tokenStarted = false
+		}
+	}
+
+	for _, r := range logOpts {
+		if escaped {
+			arg.WriteRune(r)
+			escaped = false
+			tokenStarted = true
+			continue
+		}
+
+		if r == '\\' && quote != '\'' {
+			escaped = true
+			tokenStarted = true
+			continue
+		}
+
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				continue
+			}
+			arg.WriteRune(r)
+			tokenStarted = true
+			continue
+		}
+
+		switch {
+		case r == '\'' || r == '"':
+			quote = r
+			tokenStarted = true
+		case unicode.IsSpace(r):
+			flush()
+		default:
+			arg.WriteRune(r)
+			tokenStarted = true
+		}
+	}
+
+	if escaped {
+		arg.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote in --log-opts")
+	}
+	flush()
+
+	return args, nil
 }
 
 // DiffFilesCh returns a channel with *gitdiff.File.

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -1,5 +1,99 @@
 package sources
 
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseLogOpts(t *testing.T) {
+	args, err := parseLogOpts(`--full-history --all -- '--no-notes' ":(exclude)cypress/**/*" --grep="two words"`)
+	if err != nil {
+		t.Fatalf("parseLogOpts returned error: %v", err)
+	}
+
+	want := []string{
+		"--full-history",
+		"--all",
+		"--",
+		"--no-notes",
+		":(exclude)cypress/**/*",
+		"--grep=two words",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("parseLogOpts() = %#v, want %#v", args, want)
+	}
+}
+
+func TestNewGitLogCmdWithQuotedNoNotes(t *testing.T) {
+	repo := createGitRepoWithNote(t)
+
+	cmd, err := NewGitLogCmd(repo, `'--no-notes'`)
+	if err != nil {
+		t.Fatalf("NewGitLogCmd returned error: %v", err)
+	}
+
+	var messages []string
+	for file := range cmd.DiffFilesCh() {
+		if file.PatchHeader != nil {
+			messages = append(messages, file.PatchHeader.Message())
+		}
+	}
+	for err := range cmd.ErrCh() {
+		if err != nil {
+			t.Fatalf("git stderr error: %v", err)
+		}
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("git log command failed: %v", err)
+	}
+
+	message := strings.Join(messages, "\n")
+	if !strings.Contains(message, "add secret") {
+		t.Fatalf("expected commit message in git log output, got %q", message)
+	}
+	if strings.Contains(message, "sensitive note line") {
+		t.Fatalf("expected --no-notes to omit git note, got %q", message)
+	}
+}
+
+func createGitRepoWithNote(t *testing.T) string {
+	t.Helper()
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+	runGit(t, repo, "config", "user.name", "Test User")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+
+	if err := os.WriteFile(
+		filepath.Join(repo, "secret.txt"),
+		[]byte("token = not-a-real-secret\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	runGit(t, repo, "add", "secret.txt")
+	runGit(t, repo, "commit", "-q", "-m", "add secret", "-m", "body line")
+	runGit(t, repo, "notes", "add", "-m", "sensitive note line")
+
+	return repo
+}
+
+func runGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
 // TODO: commenting out this test for now because it's flaky. Alternatives to consider to get this working:
 // -- use `git stash` instead of `restore()`
 


### PR DESCRIPTION
### Description:
Fixes #2003.

This parses `--log-opts` with shell-style quote handling before passing arguments to `git log`. Quoted options such as `'--no-notes'` now reach Git as `--no-notes`, so git notes are omitted from commit metadata and CSV output as expected. The parser also preserves quoted pathspecs and values containing spaces.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

### Tests:
- `GOMODCACHE=/Users/deepakkudi23/ai-resume-contrib-100/gitleaks/.gomodcache GOCACHE=/Users/deepakkudi23/ai-resume-contrib-100/gitleaks/.gocache go test ./sources -run 'Test(ParseLogOpts|NewGitLogCmdWithQuotedNoNotes)'`
- `GOMODCACHE=/Users/deepakkudi23/ai-resume-contrib-100/gitleaks/.gomodcache GOCACHE=/Users/deepakkudi23/ai-resume-contrib-100/gitleaks/.gocache go test ./sources`
- `GOMODCACHE=/Users/deepakkudi23/ai-resume-contrib-100/gitleaks/.gomodcache GOCACHE=/Users/deepakkudi23/ai-resume-contrib-100/gitleaks/.gocache go test ./...`
- CLI repro with a temporary git repo containing a note, `--log-opts "'--no-notes'"`, and CSV output
- `git diff --check`