### PR TITLE
fix: reduce generic api key false positives in JS properties

### DIFF
--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -45,6 +45,12 @@ func GenericCredential() *config.Rule {
 				},
 			},
 			{
+				Description: "Allow JS instance property assignments to identifiers",
+				Regexes: []*regexp.Regexp{
+					regexp.MustCompile(`^(?:this|self)\.[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*$`),
+				},
+			},
+			{
 				Description:    "Allowlist for Generic API Keys",
 				MatchCondition: config.AllowlistMatchOr,
 				RegexTarget:    "match",
@@ -130,6 +136,7 @@ func GenericCredential() *config.Rule {
 
 		// API
 		`some_api_token_123 = "`+newPlausibleSecret(`[a-zA-Z0-9]{60}`)+`"`,
+		`this.api_key = "`+newPlausibleSecret(`[a-zA-Z0-9]{60}`)+`"`,
 
 		// Auth
 		`"user_auth": "am9obmRvZTpkMDY5NGIxYi1jMTcxLTQ4ODYt+TMyYS0wMmUwOWQ1/mIwNjc="`,
@@ -272,6 +279,8 @@ DYNATRACE_API_KEY=`,
 		`snowflake.password=
 jdbc.snowflake.url=`,
 		`import { chain_Anvil1_Key, chain_Anvil2_Key } from '../blockchain-tests/pallets/supported-chains/consts';`,
+		`function x(e){return e.unk_token=e.unk_token,this.vocab=new Array(this.tokens)}`,
+		`function x(e){return e.unk_token=e.unk_token,self.vocab=new Array(self.tokens)}`,
 
 		// Yocto/BitBake
 		`SRCREV_moby = "43fc912ef59a83054ea7f6706df4d53a7dea4d80"`,

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -656,6 +656,11 @@ regexes = [
     '''^[a-zA-Z_.-]+$''',
 ]
 [[rules.allowlists]]
+description = "Allow JS instance property assignments to identifiers"
+regexes = [
+    '''^(?:this|self)\.[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*$''',
+]
+[[rules.allowlists]]
 description = "Allowlist for Generic API Keys"
 regexTarget = "match"
 regexes = [


### PR DESCRIPTION
### Description:
Fixes #1837.

This reduces a `generic-api-key` false positive seen in minified JavaScript where normal instance property assignments such as `this.vocab=new` are captured as secrets.

The change adds a narrow allowlist for JS instance property assignments whose value is another identifier, limited to:

- `this.<identifier>=<identifier>`
- `self.<identifier>=<identifier>`

It also adds regression coverage to the generated rule validation examples for the reported `this.vocab=new` shape and the equivalent `self.vocab=new` shape. A positive example for `this.api_key = "..."` remains in the true-positive set so string-valued secrets on instance properties are still detected.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

Validation run:

```sh
go generate ./...
go test ./cmd/generate/config/... ./config ./detect
go test ./...
go fmt ./...
git diff --check
```
