### PR TITLE
chore: supply-chain hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default — every PR requires at least one org member review.
+*                          @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+
+# Release-critical paths
+/.github/                  @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+/.goreleaser.yml           @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+/go.mod                    @bryanbeverly @dustin-decker @dxa4481 @zricethezav
+/go.sum                    @bryanbeverly @dustin-decker @dxa4481 @zricethezav

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in gitleaks, please report it responsibly:
+
+1. **Do not open a public issue.**
+2. Use [GitHub's private vulnerability reporting](https://github.com/gitleaks/gitleaks/security/advisories/new) to submit your report directly.
+3. Include a description of the vulnerability, steps to reproduce, and any relevant logs or screenshots.
+
+## Scope
+
+This policy covers `gitleaks` (this repository). For vulnerabilities in `gitleaks-action`, please report them at [gitleaks/gitleaks-action](https://github.com/gitleaks/gitleaks-action/security/advisories/new).


### PR DESCRIPTION
## Summary

Adds supply-chain hardening measures to gitleaks, consistent with what was done on [gitleaks-action (#219)](https://github.com/gitleaks/gitleaks-action/pull/219).

### Changes

- **CODEOWNERS** -- Default owner (all 4 org members) plus explicit protection on release-critical paths (`.github/`, `.goreleaser.yml`, `go.mod`, `go.sum`)
- **SECURITY.md** -- Vulnerability disclosure policy using GitHub private reporting, with scope cross-linking to gitleaks-action
- **Dependabot** -- Weekly Go module and GitHub Actions dependency updates, with actions grouped to reduce PR noise

### Companion changes (not in this PR)

- Branch protection on `master` (already enabled)
- Tag protection ruleset for semver tags (separate repo settings change)

## Test plan

- [ ] CODEOWNERS triggers review requests correctly
- [ ] Dependabot begins opening PRs after merge

Made with [Cursor](https://cursor.com)