### PR TITLE
Fix composite withinColumns cross-line matching

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -673,7 +673,6 @@ func (d *Detector) hasAllRequiredRules(auxiliaryFindings []*report.RequiredFindi
 }
 
 func (d *Detector) withinProximity(primary, required report.Finding, requiredRule *config.Required) bool {
-	// fmt.Println(requiredRule.WithinLines)
 	// If neither within_lines nor within_columns is set, findings just need to be in the same fragment
 	if requiredRule.WithinLines == nil && requiredRule.WithinColumns == nil {
 		return true
@@ -689,6 +688,9 @@ func (d *Detector) withinProximity(primary, required report.Finding, requiredRul
 
 	// Check column proximity (horizontal distance)
 	if requiredRule.WithinColumns != nil {
+		if primary.StartLine != required.StartLine {
+			return false
+		}
 		// Use the start column of each finding for proximity calculation
 		colDiff := abs(primary.StartColumn - required.StartColumn)
 		if colDiff > *requiredRule.WithinColumns {

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -826,6 +826,66 @@ const token = "mockSecret";
 	}
 }
 
+func TestDetectCompositeWithinColumns(t *testing.T) {
+	viper.Reset()
+	viper.AddConfigPath(configPath)
+	viper.SetConfigName("composite_within_columns")
+	viper.SetConfigType("toml")
+	err := viper.ReadInConfig()
+	require.NoError(t, err)
+
+	var vc config.ViperConfig
+	err = viper.Unmarshal(&vc)
+	require.NoError(t, err)
+
+	cfg, err := vc.Translate()
+	require.NoError(t, err)
+	cfg.Path = filepath.Join(configPath, "composite_within_columns.toml")
+
+	tests := map[string]struct {
+		fragment         Fragment
+		expectedFindings []report.Finding
+	}{
+		"same line within columns": {
+			fragment: Fragment{
+				Raw: `username = "admin" password = "secret123"`,
+			},
+			expectedFindings: []report.Finding{
+				{
+					Description: "Primary rule",
+					RuleID:      "primary-rule",
+					StartLine:   0,
+					EndLine:     0,
+					StartColumn: 20,
+					EndColumn:   41,
+					Line:        `username = "admin" password = "secret123"`,
+					Match:       `password = "secret123"`,
+					Secret:      "secret123",
+					Entropy:     2.9477028,
+					Tags:        []string{},
+				},
+			},
+		},
+		"same line outside columns": {
+			fragment: Fragment{
+				Raw: `username = "admin"                     password = "secret123"`,
+			},
+		},
+		"different lines with close columns": {
+			fragment: Fragment{
+				Raw: "username = \"admin\"\npassword = \"secret123\"",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			detector := NewDetector(cfg)
+			findings := detector.Detect(tt.fragment)
+			compare(t, findings, tt.expectedFindings)
+		})
+	}
+}
 func stripANSI(s string) string {
 	ansiRegex := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	return ansiRegex.ReplaceAllString(s, "")

--- a/testdata/config/composite_within_columns.toml
+++ b/testdata/config/composite_within_columns.toml
@@ -1,0 +1,15 @@
+title = "Composite rule within columns"
+
+[[rules]]
+id = "primary-rule"
+description = "Primary rule"
+regex = 'password\s*=\s*"([^"]+)"'
+[[rules.required]]
+id = "username-rule"
+withinColumns = 20
+
+[[rules]]
+id = "username-rule"
+description = "Username rule"
+regex = 'username\s*=\s*"([^"]+)"'
+skipReport = true


### PR DESCRIPTION
### Description

This fixes composite rule proximity so withinColumns is treated as a same-line horizontal constraint. Previously, findings on different lines could match if their start columns were close.

### Changes

- Return false for withinColumns when primary and required findings are on different lines.
- Add regression coverage for same-line within/outside column proximity and cross-line close-column proximity.
- Remove a stale commented debug print in withinProximity.

### Checklist

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

### Test Plan

- go test ./detect -run TestDetectCompositeWithinColumns -count=1
- go test ./detect -count=1