### PR TITLE
fix(detect): remove duplicate regex call in detectRule (#2121)

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -449,7 +449,7 @@ func (d *Detector) detectRule(fragment Fragment, currentRaw string, r config.Rul
 
 	// use currentRaw instead of fragment.Raw since this represents the current
 	// decoding pass on the text
-	for _, matchIndex := range r.Regex.FindAllStringIndex(currentRaw, -1) {
+	for _, matchIndex := range matches {
 		// Extract secret from match
 		secret := strings.Trim(currentRaw[matchIndex[0]:matchIndex[1]], "\n")
 


### PR DESCRIPTION
## Description

Replaces the second `FindAllStringIndex` call in `detectRule()` with the already-stored `matches` variable from the first call. The function was running the same regex twice on every fragment — once to check if matches exist (line 442), then again to iterate over them (line 452). Since regex execution is the dominant CPU cost in gitleaks (which scans files using 40+ concurrent goroutines), this change cuts per-fragment regex work in half.

**Changes:** 1 line changed in `detect/detect.go`.

Fixes #2121

---
*This PR was created with AI assistance.*