### PR TITLE
feat(sdk): add embeddable scanner, canary, and vector state APIs

### DIFF
--- a/sdk/canary.go
+++ b/sdk/canary.go
@@ -1,0 +1,93 @@
+package sdk
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+	ckregexp "github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+const canaryRuleID = "sdk-canary-token"
+
+// AddCanaryRule appends a canary token rule to cfg.
+//
+// The generated rule matches values such as "org_canary_abc123..." or
+// "honey-token-...", depending on the provided prefixes.
+func AddCanaryRule(cfg *config.Config, prefixes ...string) error {
+	if cfg == nil {
+		return errors.New("config is nil")
+	}
+	if len(prefixes) == 0 {
+		prefixes = []string{"org_canary", "honeytoken", "canary"}
+	}
+
+	cleanPrefixes := normalizePrefixes(prefixes)
+	if len(cleanPrefixes) == 0 {
+		return errors.New("at least one non-empty canary prefix is required")
+	}
+
+	if cfg.Rules == nil {
+		cfg.Rules = map[string]config.Rule{}
+	}
+	if cfg.Keywords == nil {
+		cfg.Keywords = map[string]struct{}{}
+	}
+
+	cfg.Rules[canaryRuleID] = config.Rule{
+		RuleID:      canaryRuleID,
+		Description: "Detects canary or honeytoken markers for leak monitoring.",
+		Regex:       buildCanaryPattern(cleanPrefixes),
+		Keywords:    cleanPrefixes,
+	}
+
+	for _, prefix := range cleanPrefixes {
+		cfg.Keywords[prefix] = struct{}{}
+	}
+
+	if !contains(cfg.OrderedRules, canaryRuleID) {
+		cfg.OrderedRules = append(cfg.OrderedRules, canaryRuleID)
+	}
+
+	return nil
+}
+
+func buildCanaryPattern(prefixes []string) *ckregexp.Regexp {
+	quoted := make([]string, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		quoted = append(quoted, regexp.QuoteMeta(prefix))
+	}
+
+	// Prefix plus marker body to avoid noisy matches on plain words.
+	pattern := `(?i)\b(?:` + strings.Join(quoted, "|") + `)[_.:-]?[a-z0-9][a-z0-9_-]{9,127}\b`
+	return ckregexp.MustCompile(pattern)
+}
+
+func normalizePrefixes(prefixes []string) []string {
+	seen := map[string]struct{}{}
+	res := make([]string, 0, len(prefixes))
+
+	for _, prefix := range prefixes {
+		p := strings.ToLower(strings.TrimSpace(prefix))
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		res = append(res, p)
+	}
+
+	return res
+}
+
+func contains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/canary_test.go
+++ b/sdk/canary_test.go
@@ -1,0 +1,58 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func TestAddCanaryRule_DefaultPrefixes(t *testing.T) {
+	cfg := config.Config{}
+
+	if err := AddCanaryRule(&cfg); err != nil {
+		t.Fatalf("AddCanaryRule() error = %v", err)
+	}
+
+	rule, ok := cfg.Rules[canaryRuleID]
+	if !ok {
+		t.Fatalf("expected canary rule %q", canaryRuleID)
+	}
+
+	if rule.Regex == nil {
+		t.Fatalf("expected canary regex to be set")
+	}
+
+	if _, ok := cfg.Keywords["org_canary"]; !ok {
+		t.Fatalf("expected org_canary keyword")
+	}
+}
+
+func TestAddCanaryRule_CustomPrefixesDetect(t *testing.T) {
+	cfg := config.Config{}
+	if err := AddCanaryRule(&cfg, "teamtrap"); err != nil {
+		t.Fatalf("AddCanaryRule() error = %v", err)
+	}
+
+	scanner := NewScanner(cfg)
+	findings, err := scanner.ScanString("value=teamtrap_abcdef123456789")
+	if err != nil {
+		t.Fatalf("ScanString() error = %v", err)
+	}
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 canary finding, got %d", len(findings))
+	}
+
+	if findings[0].RuleID != canaryRuleID {
+		t.Fatalf("expected rule %q, got %q", canaryRuleID, findings[0].RuleID)
+	}
+}
+
+func TestAddCanaryRule_RejectsEmptyPrefixes(t *testing.T) {
+	cfg := config.Config{}
+
+	err := AddCanaryRule(&cfg, "", " ")
+	if err == nil {
+		t.Fatalf("expected error for empty prefixes")
+	}
+}

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -1,0 +1,63 @@
+package sdk
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/spf13/viper"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+var viperMu sync.Mutex
+
+// LoadConfigFromFile reads and translates a gitleaks TOML config file.
+func LoadConfigFromFile(path string) (config.Config, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return config.Config{}, err
+	}
+	defer file.Close()
+
+	return loadConfig(path, file)
+}
+
+// LoadConfigFromString reads and translates an in-memory gitleaks TOML config.
+func LoadConfigFromString(toml string) (config.Config, error) {
+	return loadConfig("", strings.NewReader(toml))
+}
+
+// LoadDefaultConfig reads and translates the embedded default gitleaks config.
+func LoadDefaultConfig() (config.Config, error) {
+	return loadConfig("", strings.NewReader(config.DefaultConfig))
+}
+
+func loadConfig(path string, reader io.Reader) (config.Config, error) {
+	viperMu.Lock()
+	defer viperMu.Unlock()
+
+	viper.Reset()
+	defer viper.Reset()
+
+	if path != "" {
+		viper.SetConfigFile(path)
+		if err := viper.ReadInConfig(); err != nil {
+			return config.Config{}, err
+		}
+	} else {
+		viper.SetConfigType("toml")
+		if err := viper.ReadConfig(reader); err != nil {
+			return config.Config{}, err
+		}
+	}
+
+	var vc config.ViperConfig
+	if err := viper.Unmarshal(&vc); err != nil {
+		return config.Config{}, fmt.Errorf("unmarshal config: %w", err)
+	}
+
+	return vc.Translate()
+}

--- a/sdk/scanner.go
+++ b/sdk/scanner.go
@@ -1,0 +1,217 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/detect"
+	"github.com/zricethezav/gitleaks/v8/report"
+	"github.com/zricethezav/gitleaks/v8/sources"
+)
+
+// Option mutates scanner behavior.
+type Option func(*Scanner)
+
+// Scanner wraps gitleaks detector orchestration for embedding use-cases.
+type Scanner struct {
+	config            config.Config
+	redact            uint
+	maxDecodeDepth    int
+	maxArchiveDepth   int
+	maxTargetMegaByte int
+	followSymlinks    bool
+	ignoreAllow       bool
+	ignoreFiles       []string
+}
+
+// ScanResult bundles raw findings with the computed vector state.
+type ScanResult struct {
+	Findings []report.Finding
+	State    VectorState
+}
+
+// NewScanner creates a reusable scanner with immutable config and options.
+func NewScanner(cfg config.Config, opts ...Option) *Scanner {
+	s := &Scanner{config: cfg}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func WithRedact(level uint) Option {
+	return func(s *Scanner) { s.redact = level }
+}
+
+func WithMaxDecodeDepth(depth int) Option {
+	return func(s *Scanner) { s.maxDecodeDepth = depth }
+}
+
+func WithMaxArchiveDepth(depth int) Option {
+	return func(s *Scanner) { s.maxArchiveDepth = depth }
+}
+
+func WithMaxTargetMegaBytes(limit int) Option {
+	return func(s *Scanner) { s.maxTargetMegaByte = limit }
+}
+
+func WithFollowSymlinks(enabled bool) Option {
+	return func(s *Scanner) { s.followSymlinks = enabled }
+}
+
+func WithIgnoreGitleaksAllow(enabled bool) Option {
+	return func(s *Scanner) { s.ignoreAllow = enabled }
+}
+
+func WithGitleaksIgnorePath(path string) Option {
+	return func(s *Scanner) { s.ignoreFiles = append(s.ignoreFiles, path) }
+}
+
+// ScanString scans a string payload and returns findings.
+func (s *Scanner) ScanString(content string) ([]report.Finding, error) {
+	d, err := s.newDetector(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return d.DetectString(content), nil
+}
+
+// ScanStringWithState scans a string payload and computes vector state.
+func (s *Scanner) ScanStringWithState(content string, exemptions *ExemptionManager) (ScanResult, error) {
+	findings, err := s.ScanString(content)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	return scanResult(findings, exemptions), nil
+}
+
+// ScanBytes scans bytes and returns findings.
+func (s *Scanner) ScanBytes(content []byte) ([]report.Finding, error) {
+	d, err := s.newDetector(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return d.DetectBytes(content), nil
+}
+
+// ScanBytesWithState scans bytes and computes vector state.
+func (s *Scanner) ScanBytesWithState(content []byte, exemptions *ExemptionManager) (ScanResult, error) {
+	findings, err := s.ScanBytes(content)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	return scanResult(findings, exemptions), nil
+}
+
+// ScanPath scans files under the provided path.
+func (s *Scanner) ScanPath(ctx context.Context, path string) ([]report.Finding, error) {
+	d, err := s.newDetector(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	files := &sources.Files{
+		Config:          &d.Config,
+		FollowSymlinks:  d.FollowSymlinks,
+		MaxFileSize:     d.MaxTargetMegaBytes * 1_000_000,
+		Path:            path,
+		Sema:            d.Sema,
+		MaxArchiveDepth: d.MaxArchiveDepth,
+	}
+
+	return d.DetectSource(ctx, files)
+}
+
+// ScanPathWithState scans files under path and computes vector state.
+func (s *Scanner) ScanPathWithState(ctx context.Context, path string, exemptions *ExemptionManager) (ScanResult, error) {
+	findings, err := s.ScanPath(ctx, path)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	return scanResult(findings, exemptions), nil
+}
+
+// ScanGit scans git history using optional git log flags.
+func (s *Scanner) ScanGit(ctx context.Context, repoPath string, logOpts string) ([]report.Finding, error) {
+	d, err := s.newDetector(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd, err := sources.NewGitLogCmdContext(ctx, repoPath, logOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	gitSource := &sources.Git{
+		Cmd:             cmd,
+		Config:          &d.Config,
+		Sema:            d.Sema,
+		MaxArchiveDepth: d.MaxArchiveDepth,
+	}
+	return d.DetectSource(ctx, gitSource)
+}
+
+// ScanGitWithState scans git history and computes vector state.
+func (s *Scanner) ScanGitWithState(ctx context.Context, repoPath string, logOpts string, exemptions *ExemptionManager) (ScanResult, error) {
+	findings, err := s.ScanGit(ctx, repoPath, logOpts)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	return scanResult(findings, exemptions), nil
+}
+
+// ScanGitStaged scans the staged git diff in a repository.
+func (s *Scanner) ScanGitStaged(ctx context.Context, repoPath string) ([]report.Finding, error) {
+	d, err := s.newDetector(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd, err := sources.NewGitDiffCmdContext(ctx, repoPath, true)
+	if err != nil {
+		return nil, err
+	}
+
+	gitSource := &sources.Git{
+		Cmd:             cmd,
+		Config:          &d.Config,
+		Sema:            d.Sema,
+		MaxArchiveDepth: d.MaxArchiveDepth,
+	}
+	return d.DetectSource(ctx, gitSource)
+}
+
+// ScanGitStagedWithState scans staged git diff and computes vector state.
+func (s *Scanner) ScanGitStagedWithState(ctx context.Context, repoPath string, exemptions *ExemptionManager) (ScanResult, error) {
+	findings, err := s.ScanGitStaged(ctx, repoPath)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	return scanResult(findings, exemptions), nil
+}
+
+func scanResult(findings []report.Finding, exemptions *ExemptionManager) ScanResult {
+	return ScanResult{
+		Findings: findings,
+		State:    EvaluateVectorState(findings, exemptions),
+	}
+}
+
+func (s *Scanner) newDetector(ctx context.Context) (*detect.Detector, error) {
+	d := detect.NewDetectorContext(ctx, s.config)
+	d.Redact = s.redact
+	d.MaxDecodeDepth = s.maxDecodeDepth
+	d.MaxArchiveDepth = s.maxArchiveDepth
+	d.MaxTargetMegaBytes = s.maxTargetMegaByte
+	d.FollowSymlinks = s.followSymlinks
+	d.IgnoreGitleaksAllow = s.ignoreAllow
+
+	for _, ignorePath := range s.ignoreFiles {
+		if err := d.AddGitleaksIgnore(ignorePath); err != nil {
+			return nil, err
+		}
+	}
+
+	return d, nil
+}

--- a/sdk/scanner_test.go
+++ b/sdk/scanner_test.go
@@ -1,0 +1,128 @@
+package sdk
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+func TestLoadConfigFromString(t *testing.T) {
+	toml := `
+title = "sdk-test"
+
+[[rules]]
+id = "test-rule"
+description = "test rule"
+regex = '''testsecret_[A-Za-z0-9]{6}'''
+keywords = ["testsecret_"]
+`
+
+	cfg, err := LoadConfigFromString(toml)
+	if err != nil {
+		t.Fatalf("LoadConfigFromString() error = %v", err)
+	}
+
+	if cfg.Title != "sdk-test" {
+		t.Fatalf("expected title sdk-test, got %q", cfg.Title)
+	}
+
+	if _, ok := cfg.Rules["test-rule"]; !ok {
+		t.Fatalf("expected translated rule test-rule")
+	}
+}
+
+func TestScannerScanStringDoesNotAccumulateFindings(t *testing.T) {
+	scanner := NewScanner(testConfig())
+
+	first, err := scanner.ScanString("value=testsecret_ABC123")
+	if err != nil {
+		t.Fatalf("ScanString() first call error = %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("expected 1 finding on first call, got %d", len(first))
+	}
+
+	second, err := scanner.ScanString("value=testsecret_ABC123")
+	if err != nil {
+		t.Fatalf("ScanString() second call error = %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("expected 1 finding on second call, got %d", len(second))
+	}
+}
+
+func TestScannerScanPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(target, []byte("value=testsecret_ABC123\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	scanner := NewScanner(testConfig())
+	findings, err := scanner.ScanPath(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("ScanPath() error = %v", err)
+	}
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+
+	if findings[0].RuleID != "test-rule" {
+		t.Fatalf("expected rule test-rule, got %q", findings[0].RuleID)
+	}
+}
+
+func TestScannerScanStringWithState_Negative(t *testing.T) {
+	scanner := NewScanner(testConfig())
+
+	result, err := scanner.ScanStringWithState("value=testsecret_ABC123", nil)
+	if err != nil {
+		t.Fatalf("ScanStringWithState() error = %v", err)
+	}
+
+	if result.State != VectorStateNegative {
+		t.Fatalf("expected %q state, got %q", VectorStateNegative, result.State)
+	}
+
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(result.Findings))
+	}
+}
+
+func TestScannerScanStringWithState_PositiveWithRuleExemption(t *testing.T) {
+	scanner := NewScanner(testConfig())
+	exemptions := NewExemptionManager()
+	exemptions.AddRuleID("test-rule")
+
+	result, err := scanner.ScanStringWithState("value=testsecret_ABC123", exemptions)
+	if err != nil {
+		t.Fatalf("ScanStringWithState() error = %v", err)
+	}
+
+	if result.State != VectorStatePositive {
+		t.Fatalf("expected %q state, got %q", VectorStatePositive, result.State)
+	}
+}
+
+func testConfig() config.Config {
+	return config.Config{
+		Title: "sdk-test",
+		Rules: map[string]config.Rule{
+			"test-rule": {
+				RuleID:      "test-rule",
+				Description: "test rule",
+				Regex:       regexp.MustCompile(`testsecret_[A-Za-z0-9]{6}`),
+				Keywords:    []string{"testsecret_"},
+			},
+		},
+		Keywords: map[string]struct{}{
+			"testsecret_": {},
+		},
+		OrderedRules: []string{"test-rule"},
+	}
+}

--- a/sdk/state.go
+++ b/sdk/state.go
@@ -1,0 +1,106 @@
+package sdk
+
+import "github.com/zricethezav/gitleaks/v8/report"
+
+// VectorState models scan-state posture after applying exemptions.
+type VectorState string
+
+const (
+	VectorStateEmpty    VectorState = "empty"
+	VectorStatePositive VectorState = "positive"
+	VectorStateNegative VectorState = "negative"
+	VectorStateAnti     VectorState = "anti"
+)
+
+// ExemptionManager holds finding matchers considered exempt.
+type ExemptionManager struct {
+	fingerprints map[string]struct{}
+	ruleIDs      map[string]struct{}
+	paths        map[string]struct{}
+}
+
+// NewExemptionManager creates an empty exemption manager.
+func NewExemptionManager() *ExemptionManager {
+	return &ExemptionManager{
+		fingerprints: map[string]struct{}{},
+		ruleIDs:      map[string]struct{}{},
+		paths:        map[string]struct{}{},
+	}
+}
+
+// AddFingerprint exempts a finding fingerprint.
+func (e *ExemptionManager) AddFingerprint(fingerprint string) {
+	if e == nil || fingerprint == "" {
+		return
+	}
+	e.fingerprints[fingerprint] = struct{}{}
+}
+
+// AddRuleID exempts all findings produced by a rule.
+func (e *ExemptionManager) AddRuleID(ruleID string) {
+	if e == nil || ruleID == "" {
+		return
+	}
+	e.ruleIDs[ruleID] = struct{}{}
+}
+
+// AddPath exempts all findings from a path.
+func (e *ExemptionManager) AddPath(path string) {
+	if e == nil || path == "" {
+		return
+	}
+	e.paths[path] = struct{}{}
+}
+
+// IsExempt reports whether finding is exempt based on configured matchers.
+func (e *ExemptionManager) IsExempt(f report.Finding) bool {
+	if e == nil {
+		return false
+	}
+	if _, ok := e.fingerprints[f.Fingerprint]; ok {
+		return true
+	}
+	if _, ok := e.ruleIDs[f.RuleID]; ok {
+		return true
+	}
+	if _, ok := e.paths[f.File]; ok {
+		return true
+	}
+	return false
+}
+
+// EvaluateVectorState determines vector state for findings after exemptions.
+//
+// States:
+// - empty: no findings
+// - positive: findings exist but all exempt
+// - negative: at least one non-exempt finding
+// - anti: malformed findings detected (policy-unsafe state)
+func EvaluateVectorState(findings []report.Finding, exemptions *ExemptionManager) VectorState {
+	if len(findings) == 0 {
+		return VectorStateEmpty
+	}
+
+	activeCount := 0
+	exemptCount := 0
+
+	for _, finding := range findings {
+		if finding.RuleID == "" {
+			return VectorStateAnti
+		}
+		if exemptions != nil && exemptions.IsExempt(finding) {
+			exemptCount++
+			continue
+		}
+		activeCount++
+	}
+
+	if activeCount > 0 {
+		return VectorStateNegative
+	}
+	if exemptCount > 0 {
+		return VectorStatePositive
+	}
+
+	return VectorStateEmpty
+}

--- a/sdk/state_test.go
+++ b/sdk/state_test.go
@@ -1,0 +1,59 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/zricethezav/gitleaks/v8/report"
+)
+
+func TestEvaluateVectorState_Empty(t *testing.T) {
+	state := EvaluateVectorState(nil, nil)
+	if state != VectorStateEmpty {
+		t.Fatalf("expected %q, got %q", VectorStateEmpty, state)
+	}
+}
+
+func TestEvaluateVectorState_Negative(t *testing.T) {
+	findings := []report.Finding{{RuleID: canaryRuleID, File: "a.txt", Fingerprint: "fp1"}}
+	state := EvaluateVectorState(findings, nil)
+	if state != VectorStateNegative {
+		t.Fatalf("expected %q, got %q", VectorStateNegative, state)
+	}
+}
+
+func TestEvaluateVectorState_PositiveWhenExempt(t *testing.T) {
+	findings := []report.Finding{{RuleID: canaryRuleID, File: "a.txt", Fingerprint: "fp1"}}
+	exemptions := NewExemptionManager()
+	exemptions.AddFingerprint("fp1")
+
+	state := EvaluateVectorState(findings, exemptions)
+	if state != VectorStatePositive {
+		t.Fatalf("expected %q, got %q", VectorStatePositive, state)
+	}
+}
+
+func TestEvaluateVectorState_AntiMalformedFinding(t *testing.T) {
+	findings := []report.Finding{{RuleID: "", File: "a.txt", Fingerprint: "fp1"}}
+	state := EvaluateVectorState(findings, nil)
+	if state != VectorStateAnti {
+		t.Fatalf("expected %q, got %q", VectorStateAnti, state)
+	}
+}
+
+func TestExemptionManager_RuleAndPath(t *testing.T) {
+	exemptions := NewExemptionManager()
+	exemptions.AddRuleID(canaryRuleID)
+	exemptions.AddPath("b.txt")
+
+	if !exemptions.IsExempt(report.Finding{RuleID: canaryRuleID, File: "a.txt"}) {
+		t.Fatalf("expected rule exemption to match")
+	}
+
+	if !exemptions.IsExempt(report.Finding{RuleID: "other", File: "b.txt"}) {
+		t.Fatalf("expected path exemption to match")
+	}
+
+	if exemptions.IsExempt(report.Finding{RuleID: "other", File: "c.txt"}) {
+		t.Fatalf("unexpected exemption match")
+	}
+}


### PR DESCRIPTION
## Summary
This PR introduces an embeddable SDK surface for gitleaks so projects can consume detection capabilities programmatically.

## What is included
- SDK config loading helpers (file, string, default)
- Reusable scanner abstraction and options
- Scanner methods for string, bytes, path, git history, and staged git
- Canary rule helper for honeytoken-style detection
- Exemption management for findings (fingerprint, rule ID, file path)
- Vector-state evaluation (`empty`, `positive`, `negative`, `anti`)
- Scanner convenience methods returning findings + vector state
- Unit tests for the full SDK surface

## Validation
- `go test ./sdk`

Closes #2152
Closes #2153
