### PR TITLE
chore(github): add SDK embedding issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/sdk_embedding.md
+++ b/.github/ISSUE_TEMPLATE/sdk_embedding.md
@@ -1,0 +1,40 @@
+---
+name: SDK embedding request
+about: Request a programmatic SDK capability or integration enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Integration context
+- Consumer language/runtime:
+- Execution environment (CI, local, service, etc.):
+- Target scan source(s):
+  - [ ] string/bytes
+  - [ ] filesystem path
+  - [ ] git history
+  - [ ] staged git diff
+
+## Problem statement
+Describe the integration pain point or missing SDK capability.
+
+## Desired API surface
+Describe the API shape you expect (types/methods/options).
+
+## Policy and output requirements
+- Need canary support:
+  - [ ] yes
+  - [ ] no
+- Need exemptions:
+  - [ ] yes
+  - [ ] no
+- Need vector state output (`empty`, `positive`, `negative`, `anti`):
+  - [ ] yes
+  - [ ] no
+- Required output format(s):
+
+## Alternatives considered
+Describe any workarounds or alternatives you tried.
+
+## Additional context
+Add logs, snippets, or references if relevant.


### PR DESCRIPTION
## Summary
Add a dedicated issue template to capture SDK embedding requests with the right integration details.

## Why
SDK requests usually need structured context (scan source, policy expectations, output needs), which is often missing in generic feature templates.

## Validation
- Template follows existing repository issue-template conventions

Closes #2155
