### PR TITLE
feat(rules): add Anthropic OAuth access and refresh token rules

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -40,6 +40,8 @@ func main() {
 		rules.AmazonBedrockAPIKeyShortLived(),
 		rules.AnthropicAdminApiKey(),
 		rules.AnthropicApiKey(),
+		rules.AnthropicOAuthToken(),
+		rules.AnthropicOAuthRefreshToken(),
 		rules.ArtifactoryApiKey(),
 		rules.ArtifactoryReferenceToken(),
 		rules.AsanaClientID(),

--- a/cmd/generate/config/rules/anthropic.go
+++ b/cmd/generate/config/rules/anthropic.go
@@ -67,3 +67,50 @@ func AnthropicAdminApiKey() *config.Rule {
 
 	return utils.Validate(r, tps, fps)
 }
+
+func AnthropicOAuthToken() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "anthropic-oauth-token",
+		Description: "Found an Anthropic OAuth access token (sk-ant-oat01-), which is tied to a Claude.ai Pro/Max subscription and can be used to act on the account's behalf.",
+		// The sk-ant-oat01- prefix is highly specific, so anchor on it. Anthropic
+		// does not publish a fixed length for OAuth tokens, so use a conservative
+		// minimum rather than the {93}AA shape used by the api03/admin01 keys.
+		Regex: utils.GenerateUniqueTokenRegex(`sk-ant-oat01-[a-zA-Z0-9_\-]{40,}`, false),
+		Keywords: []string{
+			"sk-ant-oat01",
+		},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("anthropic", "sk-ant-oat01-"+secrets.NewSecret(utils.AlphaNumericExtendedShort("100")))
+
+	fps := []string{
+		// Too short to be a real OAuth token
+		`anthropic_token = "sk-ant-oat01-tooShort"`,
+	}
+
+	return utils.Validate(r, tps, fps)
+}
+
+func AnthropicOAuthRefreshToken() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "anthropic-oauth-refresh-token",
+		Description: "Uncovered an Anthropic OAuth refresh token (sk-ant-ort01-), which can mint new access tokens and allow prolonged unauthorized access to a Claude.ai account.",
+		Regex:       utils.GenerateUniqueTokenRegex(`sk-ant-ort01-[a-zA-Z0-9_\-]{40,}`, false),
+		Keywords: []string{
+			"sk-ant-ort01",
+		},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("anthropic", "sk-ant-ort01-"+secrets.NewSecret(utils.AlphaNumericExtendedShort("100")))
+
+	fps := []string{
+		// Too short to be a real OAuth refresh token
+		`anthropic_token = "sk-ant-ort01-tooShort"`,
+	}
+
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -153,6 +153,18 @@ regex = '''\b(sk-ant-api03-[a-zA-Z0-9_\-]{93}AA)(?:[\x60'"\s;]|\\[nr]|$)'''
 keywords = ["sk-ant-api03"]
 
 [[rules]]
+id = "anthropic-oauth-refresh-token"
+description = "Uncovered an Anthropic OAuth refresh token (sk-ant-ort01-), which can mint new access tokens and allow prolonged unauthorized access to a Claude.ai account."
+regex = '''\b(sk-ant-ort01-[a-zA-Z0-9_\-]{40,})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = ["sk-ant-ort01"]
+
+[[rules]]
+id = "anthropic-oauth-token"
+description = "Found an Anthropic OAuth access token (sk-ant-oat01-), which is tied to a Claude.ai Pro/Max subscription and can be used to act on the account's behalf."
+regex = '''\b(sk-ant-oat01-[a-zA-Z0-9_\-]{40,})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = ["sk-ant-oat01"]
+
+[[rules]]
 id = "artifactory-api-key"
 description = "Detected an Artifactory api key, posing a risk unauthorized access to the central repository."
 regex = '''\bAKCp[A-Za-z0-9]{69}\b'''


### PR DESCRIPTION
Closes #2158

Adds two detection rules:

- `anthropic-oauth-token` — `sk-ant-oat01-` (OAuth access token)
- `anthropic-oauth-refresh-token` — `sk-ant-ort01-` (OAuth refresh token)

These are distinct from the existing `sk-ant-api03-`/`sk-ant-admin01-` rules. The refresh token can mint new access tokens, so leaking either is a real exposure.

Anthropic doesn't document a fixed token-body length for the OAuth tokens, so the rules anchor on the (highly specific) prefix with a conservative `{40,}` minimum rather than the `{93}AA` shape used by the api03/admin01 keys. Both rules carry tps/fps validated by `utils.Validate`, and `config/gitleaks.toml` was regenerated with `go generate ./...`.

### Tests
- `go generate ./...` (regenerates the config and runs each new rule's tps/fps through the detector)
- `go test ./detect/`
- Built the binary and confirmed it flags sample `oat01`/`ort01` tokens and ignores a too-short string.