### PR TITLE
perf(detect): reuse match results instead of scanning the fragment twice

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -439,6 +439,8 @@ func (d *Detector) detectRule(fragment Fragment, currentRaw string, r config.Rul
 		}
 	}
 
+	// use currentRaw instead of fragment.Raw since this represents the current
+	// decoding pass on the text
 	matches := r.Regex.FindAllStringIndex(currentRaw, -1)
 	if len(matches) == 0 {
 		return findings
@@ -447,9 +449,7 @@ func (d *Detector) detectRule(fragment Fragment, currentRaw string, r config.Rul
 	// TODO profile this, probably should replace with something more efficient
 	newlineIndices := newLineRegexp.FindAllStringIndex(fragment.Raw, -1)
 
-	// use currentRaw instead of fragment.Raw since this represents the current
-	// decoding pass on the text
-	for _, matchIndex := range r.Regex.FindAllStringIndex(currentRaw, -1) {
+	for _, matchIndex := range matches {
 		// Extract secret from match
 		secret := strings.Trim(currentRaw[matchIndex[0]:matchIndex[1]], "\n")
 


### PR DESCRIPTION
Closes #2160

`detectRule` ran `r.Regex.FindAllStringIndex(currentRaw, -1)` once just to check for emptiness, then ran the identical scan again to drive the loop. This iterates over the already-computed `matches` slice instead, removing one full regex pass per match-bearing fragment.

Behaviour is unchanged — each match is visited exactly once and the per-iteration mutation of `matchIndex` stays local.

### Tests
- `go test ./detect/` passes.