### PR TITLE
perf: reuse regex match results in detectRule() to avoid double regex execution

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -449,7 +449,7 @@ func (d *Detector) detectRule(fragment Fragment, currentRaw string, r config.Rul
 
 	// use currentRaw instead of fragment.Raw since this represents the current
 	// decoding pass on the text
-	for _, matchIndex := range r.Regex.FindAllStringIndex(currentRaw, -1) {
+	for _, matchIndex := range matches {
 		// Extract secret from match
 		secret := strings.Trim(currentRaw[matchIndex[0]:matchIndex[1]], "\n")
 


### PR DESCRIPTION
Fixes #2121

The `detectRule()` function called `r.Regex.FindAllStringIndex(currentRaw, -1)` twice per invocation — once to check if any matches exist (line 442), and again to iterate over those matches (line 452). Both calls received identical arguments and produced identical results; the first result was thrown away.

This doubles regex work on every fragment that passes the Aho-Corasick prefilter and contains at least one match. Regex execution is the dominant cost of a gitleaks scan.

**Change:** Reuse the `matches` variable from the first call instead of calling `FindAllStringIndex` a second time.

```diff
- for _, matchIndex := range r.Regex.FindAllStringIndex(currentRaw, -1) {
+ for _, matchIndex := range matches {
```

Zero behavioral impact — produces identical results.