### PR TITLE
Add rule for Zhipu AI (Z.ai) API keys

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -247,6 +247,7 @@ func main() {
 		rules.YandexAWSAccessToken(),
 		rules.YandexAccessToken(),
 		rules.ZendeskSecretKey(),
+		rules.ZhipuApiKey(),
 		rules.GenericCredential(),
 		rules.InfracostAPIToken(),
 	}

--- a/cmd/generate/config/rules/zhipu.go
+++ b/cmd/generate/config/rules/zhipu.go
@@ -1,0 +1,42 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func ZhipuApiKey() *config.Rule {
+	// define rule
+	// Zhipu AI / Z.ai (BigModel) keys authenticate against the GLM model APIs.
+	// They consist of a 32-character hex id and a 16-character secret joined
+	// by a period, e.g. "0123...cdef.AbCd012345678901".
+	r := config.Rule{
+		RuleID:      "zhipu-api-key",
+		Description: "Identified a Zhipu AI (Z.ai) API Key, which may compromise GLM model integrations and expose paid AI quota to unauthorized access.",
+		Regex: utils.GenerateSemiGenericRegex(
+			[]string{"zhipu", "bigmodel", "glm", "zai"},
+			`[0-9a-f]{32}\.[a-zA-Z0-9]{16}`, true),
+		Keywords: []string{
+			"zhipu",
+			"bigmodel",
+			"glm",
+			"zai",
+		},
+	}
+
+	// validate
+	tps := []string{
+		utils.GenerateSampleSecret("zhipu", secrets.NewSecret(`[0-9a-f]{32}\.[a-zA-Z0-9]{16}`)),
+		utils.GenerateSampleSecret("bigmodel", secrets.NewSecret(`[0-9a-f]{32}\.[a-zA-Z0-9]{16}`)),
+		`ZHIPU_API_KEY = "1234567890abcdef1234567890abcdef.AbCdEf0123456789"`,
+	}
+	fps := []string{
+		// Right structure but no provider keyword nearby
+		`token = "1234567890abcdef1234567890abcdef.AbCdEf0123456789"`,
+		// Wrong id length
+		`zhipu_api_key = "1234567890abcdef.AbCdEf0123456789"`,
+	}
+
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -3207,3 +3207,14 @@ description = "Detected a Zendesk Secret Key, risking unauthorized access to cus
 regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{40})(?:[\x60'"\s;]|\\[nr]|$)'''
 keywords = ["zendesk"]
 
+[[rules]]
+id = "zhipu-api-key"
+description = "Identified a Zhipu AI (Z.ai) API Key, which may compromise GLM model integrations and expose paid AI quota to unauthorized access."
+regex = '''(?i)[\w.-]{0,50}?(?:zhipu|bigmodel|glm|zai)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([0-9a-f]{32}\.[a-zA-Z0-9]{16})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = [
+    "zhipu",
+    "bigmodel",
+    "glm",
+    "zai",
+]
+


### PR DESCRIPTION
## Description

Adds a detection rule for **Zhipu AI / Z.ai (BigModel)** API keys, used to authenticate against the GLM model APIs (`https://api.z.ai/api/paas/v4`, `https://open.bigmodel.cn`).

- **Key format:** a 32-character hex id and a 16-character secret joined by a period (e.g. `0123…cdef.AbCd012345678901`).
- The token structure isn't unique on its own, so the rule uses `GenerateSemiGenericRegex` gated by the `zhipu` / `bigmodel` / `glm` / `zai` identifiers (matching common env names like `ZHIPU_API_KEY`, `GLM_API_KEY`, `ZAI_API_KEY`) to keep signal high.

## Steps followed (per CONTRIBUTING.md)

1. Added `cmd/generate/config/rules/zhipu.go`.
2. Registered `rules.ZhipuApiKey()` in `cmd/generate/config/main.go` (alphabetically, after Zendesk).
3. Ran `make config/gitleaks.toml` to regenerate the config.
4. Verified the new rule block in `config/gitleaks.toml`.

## Validation

The rule includes true-positive and false-positive cases (`utils.Validate`), which run during config generation:
- TPs: keyed samples for `zhipu` and `bigmodel`, plus a realistic `ZHIPU_API_KEY = "…"` example.
- FPs: same structure without a provider keyword, and a wrong-length id.

`gofmt`, `go vet`, and `go test ./config/... ./cmd/generate/...` all pass; `make config/gitleaks.toml` reports the config up to date.