### PR TITLE
fix(detect): surface git stderr errors instead of swallowing them (#2129)

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -226,8 +226,17 @@ func (d *Detector) DetectSource(ctx context.Context, source sources.Source) ([]r
 		logger := logContext.Logger()
 
 		if err != nil {
-			// Log the error and move on to the next fragment
 			logger.Error().Err(err).Send()
+			// A source signals a fatal, scan-aborting error by yielding it with
+			// an empty fragment (e.g. the git source when `git log` writes to
+			// stderr). Propagate it so the caller reports a partial scan and
+			// exits non-zero, instead of silently reporting "no leaks found"
+			// with exit 0. A populated fragment indicates a recoverable
+			// per-item error (e.g. a single unreadable file), which we log and
+			// skip so the rest of the scan continues. See #2129.
+			if fragment.FilePath == "" && fragment.CommitSHA == "" && len(fragment.Raw) == 0 {
+				return err
+			}
 			return nil
 		}
 

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -3,6 +3,7 @@ package detect
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -2768,6 +2769,69 @@ func TestWindowsFileSeparator_RuleAllowlistPaths(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual := d.detectRule(test.fragment, test.fragment.Raw, test.rule, []*codec.EncodedSegment{})
 			compare(t, test.expected, actual)
+		})
+	}
+}
+
+// fakeSource is a minimal sources.Source used to exercise DetectSource's
+// error-propagation contract without spawning a real git process.
+type fakeSource struct {
+	items []fakeYield
+}
+
+type fakeYield struct {
+	fragment sources.Fragment
+	err      error
+}
+
+func (s *fakeSource) Fragments(_ context.Context, yield sources.FragmentsFunc) error {
+	for _, item := range s.items {
+		if err := yield(item.fragment, item.err); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestDetectSourceErrorPropagation guards the fix for #2129: a fatal,
+// scan-aborting error (yielded with an empty fragment, as the git source does
+// when `git log` writes to stderr) must propagate out of DetectSource so the
+// CLI reports a partial scan and exits non-zero. A recoverable per-item error
+// (yielded with a populated fragment) must still be logged and skipped.
+func TestDetectSourceErrorPropagation(t *testing.T) {
+	tests := map[string]struct {
+		source    *fakeSource
+		expectErr bool
+	}{
+		"source-level error (empty fragment) propagates": {
+			source: &fakeSource{items: []fakeYield{
+				{fragment: sources.Fragment{}, err: errors.New("stderr is not empty")},
+			}},
+			expectErr: true,
+		},
+		"per-item error (populated fragment) is swallowed": {
+			source: &fakeSource{items: []fakeYield{
+				{fragment: sources.Fragment{FilePath: "broken.txt"}, err: errors.New("could not read file")},
+			}},
+			expectErr: false,
+		},
+		"clean scan returns no error": {
+			source: &fakeSource{items: []fakeYield{
+				{fragment: sources.Fragment{FilePath: "ok.txt", Raw: "nothing to see"}, err: nil},
+			}},
+			expectErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			detector := NewDetector(config.Config{})
+			_, err := detector.DetectSource(context.Background(), tt.source)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes #2129.

When the git source runs `git log` and git writes to stderr, `listenForStdErr` (in `sources/git.go`) flips any non-allowlisted line into a fatal `"stderr is not empty"` error, yielded with an **empty fragment**. `DetectSource`'s yield callback treated that the same as a recoverable per-fragment error — `logger.Error(); return nil` — so the error was swallowed. The scan aborted but reported `no leaks found` and exited **0**.

This is a silent false negative, and it triggers **by default on any [git-crypt](https://github.com/AGWA/git-crypt) repo**: git-crypt's `diff.textconv` filter writes `Warning: file not encrypted` to stderr for historical commits touching now-encrypted paths. Running `gitleaks git` on such a repo prints a clean report while scanning nothing.

## Fix

`DetectSource` now propagates **source-level** errors (yielded with an empty fragment, which is uniquely how the git source signals a fatal abort — every other error-yield carries a populated fragment) instead of swallowing them. The existing partial-scan path in `findingSummaryAndExit` then runs: it logs `partial scan completed` and exits non-zero. Recoverable **per-fragment** errors (populated fragment, e.g. one unreadable file in a directory scan) are still logged and skipped, so the rest of the scan continues.

The whole partial-scan/exit-1 machinery already existed — it was simply never reached because the error was eaten one layer up. One targeted change unblocks it.

## Before / after (real repo with a stderr-writing textconv filter)

```
# before — silent false negative
INF 0 commits scanned.
INF no leaks found
$ echo $?  → 0

# after — abort is surfaced
INF 1 commits scanned.
ERR failed to scan Git repository error="stderr is not empty"
WRN partial scan completed
WRN no leaks found in partial scan
$ echo $?  → 1
```

## Tests

Added `TestDetectSourceErrorPropagation` in `detect/detect_test.go`:
- source-level error (empty fragment) → `DetectSource` returns an error (**fails before this fix, passes after**)
- per-fragment error (populated fragment) → still swallowed (returns nil), guarding against over-propagation that would abort directory scans
- clean scan → no error

`go test ./detect/`, `go build ./...`, `gofmt`, and `go vet` (no new findings) all pass.

## Note

This restores the *intended* behavior (the `"stderr is not empty"` error and the partial-scan path already exist). If you'd rather make noisy-but-non-fatal stderr opt-in via a flag (issue #2129 option 2), happy to follow up — I kept this PR to the minimal correctness fix.

---

I used Claude Code to help locate the root cause and write the test; I reproduced the bug end-to-end and verified the before/after behavior myself.