### PR TITLE
fix: use [[allowlists]] instead of deprecated [allowlist] in default config

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -18,8 +18,7 @@ title = "gitleaks config"
 # config-enabled features are guaranteed to work.
 minVersion = "v8.25.0"
 
-# TODO: change to [[allowlists]]
-[allowlist]
+[[allowlists]]
 description = "global allow lists"
 paths = [
     '''gitleaks\.toml''',

--- a/reproduce_test.go
+++ b/reproduce_test.go
@@ -1,4 +1,0 @@
-package main
-
-// This file intentionally left blank — the fix for #2048 was applied directly
-// to config/gitleaks.toml: [allowlist] → [[allowlists]]

--- a/reproduce_test.go
+++ b/reproduce_test.go
@@ -1,0 +1,4 @@
+package main
+
+// This file intentionally left blank — the fix for #2048 was applied directly
+// to config/gitleaks.toml: [allowlist] → [[allowlists]]


### PR DESCRIPTION
## Summary

Replaces the deprecated `[allowlist]` syntax with the correct `[[allowlists]]` in the embedded default config, resolving the lingering TODO comment from [PR #1777](https://github.com/gitleaks/gitleaks/pull/1777).

## Background

The embedded `config/gitleaks.toml` (line 21-22) still contained:
```toml
# TODO: change to [[allowlists]]
[allowlist]
```

This was flagged during the review of [PR #1777](https://github.com/gitleaks/gitleaks/pull/1777/files#r2042848904) but never updated.

The config parser already supports `[[allowlists]]` via the [Allowlists field](https://github.com/gitleaks/gitleaks/blob/main/config/config.go#L58) in `ViperConfig`, and correctly detects [deprecated usage](https://github.com/gitleaks/gitleaks/blob/main/config/config.go#L220-L226) of the old `[allowlist]` field as a shim for backwards compatibility. The generated config should use the modern form.

## Change

- Line 21-22: Removed `# TODO: change to [[allowlists]]` comment and changed `[allowlist]` to `[[allowlists]]`
- The data fields (`description`, `paths`, `regexes`, `stopwords`) are unchanged

## Testing

All tests pass:
```
ok  github.com/zricethezav/gitleaks/v8/config    0.115s
ok  github.com/zricethezav/gitleaks/v8/detect    1.015s
ok  github.com/zricethezav/gitleaks/v8/report    0.009s
ok  github.com/zricethezav/gitleaks/v8/sources   0.004s
```

Fixes https://github.com/gitleaks/gitleaks/issues/2048