### PR TITLE
doc: document --platform flag in helptext & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ For example, if you wanted to run gitleaks on a range of commits you could use t
 command: `gitleaks git -v --log-opts="--all commitA..commitB" path_to_repo`. See the [git log](https://git-scm.com/docs/git-log) documentation for more information.
 If there is no target specified as a positional argument, then gitleaks will attempt to scan the current working directory as a git repo.
 
+Use `--platform` to generate links to findings on a specific SCM platform. Supported values: `github`, `gitlab`, `azuredevops`, `gitea`, `bitbucket`. Use `--staged` to scan staged (index) changes only. Use `--pre-commit` to scan unstaged working tree changes only (via `git diff`).
+
 #### Dir
 
 The `dir` (aliases include `files`, `directory`) command lets you scan directories and files. Example: `gitleaks dir -v path_to_directory_or_file`.

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -13,7 +13,7 @@ import (
 
 func init() {
 	rootCmd.AddCommand(gitCmd)
-	gitCmd.Flags().String("platform", "", "the target platform used to generate links (github, gitlab)")
+	gitCmd.Flags().String("platform", "", "the target platform used to generate links (github, gitlab, azuredevops, gitea, bitbucket)")
 	gitCmd.Flags().Bool("staged", false, "scan staged commits (good for pre-commit)")
 	gitCmd.Flags().Bool("pre-commit", false, "scan using git diff")
 	gitCmd.Flags().String("log-opts", "", "git log options")

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -13,7 +14,7 @@ import (
 
 func init() {
 	rootCmd.AddCommand(gitCmd)
-	gitCmd.Flags().String("platform", "", "the target platform used to generate links (github, gitlab, azuredevops, gitea, bitbucket)")
+	gitCmd.Flags().String("platform", "", "the target platform used to generate links ("+strings.Join(scm.UserFacingPlatforms(), ", ")+")")
 	gitCmd.Flags().Bool("staged", false, "scan staged commits (good for pre-commit)")
 	gitCmd.Flags().Bool("pre-commit", false, "scan using git diff")
 	gitCmd.Flags().String("log-opts", "", "git log options")

--- a/cmd/scm/scm.go
+++ b/cmd/scm/scm.go
@@ -30,6 +30,14 @@ func (p Platform) String() string {
 	}[p]
 }
 
+func UserFacingPlatforms() []string {
+	var platforms []string
+	for p := GitHubPlatform; p <= BitbucketPlatform; p++ {
+		platforms = append(platforms, p.String())
+	}
+	return platforms
+}
+
 func PlatformFromString(s string) (Platform, error) {
 	switch strings.ToLower(s) {
 	case "", "unknown":


### PR DESCRIPTION
Fixes: #2173

### Description:

- document supported `--platform` options
- prevent `--platform` helptext drift
-  add minimal docs for `--staged` and `--precommit` flags in the `git` command

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
