### PR TITLE
fix: only apply withinColumns proximity within the same line

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -673,7 +673,6 @@ func (d *Detector) hasAllRequiredRules(auxiliaryFindings []*report.RequiredFindi
 }
 
 func (d *Detector) withinProximity(primary, required report.Finding, requiredRule *config.Required) bool {
-	// fmt.Println(requiredRule.WithinLines)
 	// If neither within_lines nor within_columns is set, findings just need to be in the same fragment
 	if requiredRule.WithinLines == nil && requiredRule.WithinColumns == nil {
 		return true
@@ -687,9 +686,13 @@ func (d *Detector) withinProximity(primary, required report.Finding, requiredRul
 		}
 	}
 
-	// Check column proximity (horizontal distance)
+	// Check column proximity (horizontal distance). Column numbers restart at
+	// each new line, so a column comparison is only meaningful when both
+	// findings are on the same line.
 	if requiredRule.WithinColumns != nil {
-		// Use the start column of each finding for proximity calculation
+		if primary.StartLine != required.StartLine {
+			return false
+		}
 		colDiff := abs(primary.StartColumn - required.StartColumn)
 		if colDiff > *requiredRule.WithinColumns {
 			return false

--- a/detect/within_proximity_test.go
+++ b/detect/within_proximity_test.go
@@ -1,0 +1,52 @@
+package detect
+
+import (
+	"testing"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/report"
+)
+
+func TestWithinProximityColumns(t *testing.T) {
+	col := func(n int) *int { return &n }
+	d := &Detector{}
+
+	tests := []struct {
+		name             string
+		primary, require report.Finding
+		required         *config.Required
+		want             bool
+	}{
+		{
+			name:     "same line, within column distance",
+			primary:  report.Finding{StartLine: 1, StartColumn: 5},
+			require:  report.Finding{StartLine: 1, StartColumn: 8},
+			required: &config.Required{WithinColumns: col(5)},
+			want:     true,
+		},
+		{
+			name:     "same line, beyond column distance",
+			primary:  report.Finding{StartLine: 1, StartColumn: 5},
+			require:  report.Finding{StartLine: 1, StartColumn: 60},
+			required: &config.Required{WithinColumns: col(5)},
+			want:     false,
+		},
+		{
+			// Columns restart per line, so findings on different lines must never
+			// satisfy a column-proximity constraint, even if the raw numbers are close.
+			name:     "different lines never satisfy column proximity",
+			primary:  report.Finding{StartLine: 1, StartColumn: 5},
+			require:  report.Finding{StartLine: 300, StartColumn: 6},
+			required: &config.Required{WithinColumns: col(5)},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := d.withinProximity(tt.primary, tt.require, tt.required); got != tt.want {
+				t.Errorf("withinProximity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What was broken

`withinProximity()` computed `withinColumns` by subtracting the `StartColumn` of the two findings without checking they were on the same line. Column numbers restart at every new line, so the comparison is only meaningful within a single line.

Closes #2122.

## Why it matters

For composite rules this produced incorrect proximity results: a primary finding on line 1 column 5 and a required finding on line 300 column 6 gave `colDiff = 1`, satisfying `withinColumns: 5` even though the findings are 300 lines apart. The README presents `withinColumns` as a horizontal, same-line constraint.

## What changed

`withinColumns` now returns false when the two findings are on different lines, then compares columns only for same-line findings. A leftover commented-out debug print in the same function was removed.

## Tests

Added `TestWithinProximityColumns` covering same-line within range, same-line out of range, and the cross-line case. The cross-line test fails on current code (returns true) and passes with this change. `go build ./...`, `go vet ./detect/`, and the detect suite pass.
