### PR TITLE
fix: allowlist Swift private key type declarations

### DIFF
--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -101,6 +101,9 @@ func GenericCredential() *config.Rule {
 					regexp.MustCompile(`--mount=type=secret,`),
 					//  https://github.com/gitleaks/gitleaks/issues/1800
 					regexp.MustCompile(`import[ \t]+{[ \t\w,]+}[ \t]+from[ \t]+['"][^'"]+['"]`),
+					// Swift type-only declarations like `let privateKey: P256.Signing.PrivateKey`.
+					// The generic rule can read the type annotation as an assignment and capture the type name.
+					regexp.MustCompile(`^\s*(?:[\w@()]+\s+)*(?:let|var)\s+\w+\s*:\s*[A-Z][\w.<>, ?]*$`),
 				},
 			},
 			{
@@ -225,6 +228,7 @@ _LIBCPP_CONSTEXPR_AFTER_CXX11 `,
 		`pub const SN_id_Gost28147_89_None_KeyMeshing = "id-Gost28147-89-None-KeyMeshing"`,
 		`KeyPair = X25519.KeyPair`,
 		`BlindKeySignatures = Ed25519.BlindKeySignatures`,
+		`let privateKey: P256.Signing.PrivateKey`,
 		`AVEncVideoMaxKeyframeDistance, "2987123a-ba93-4704-b489-ec1e5f25292c"`,
 		`            keyPressed = kVK_Return.u16`,
 		`timezone_mapping = {

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2114,6 +2114,7 @@ regexTarget = "line"
 regexes = [
     '''--mount=type=secret,''',
     '''import[ \t]+{[ \t\w,]+}[ \t]+from[ \t]+['"][^'"]+['"]''',
+    '''^\s*(?:[\w@()]+\s+)*(?:let|var)\s+\w+\s*:\s*[A-Z][\w.<>, ?]*$''',
 ]
 [[rules.allowlists]]
 condition = "AND"


### PR DESCRIPTION
### Description:
Fixes a false positive where the generic API key rule reports Swift type-only declarations such as:

```swift
let privateKey: P256.Signing.PrivateKey
```

The fix adds a line-level allowlist for Swift `let`/`var` declarations that only annotate a type, plus a regression false-positive sample in the generated config rule source.

Closes #2182

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?

### Verification

* `go run . detect --no-git --source /tmp/swift_fp.swift --no-banner --redact --report-format=json`
* `go run . detect --no-git --source /tmp/generic_secret.txt --no-banner --redact --report-format=json`
* `go test ./cmd/generate/config/... ./config`
* `go generate ./...`
* `make test`
* `go build ./...`
