### PR TITLE
fix: withinColumns should not compare columns across different lines

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -673,7 +673,6 @@ func (d *Detector) hasAllRequiredRules(auxiliaryFindings []*report.RequiredFindi
 }
 
 func (d *Detector) withinProximity(primary, required report.Finding, requiredRule *config.Required) bool {
-	// fmt.Println(requiredRule.WithinLines)
 	// If neither within_lines nor within_columns is set, findings just need to be in the same fragment
 	if requiredRule.WithinLines == nil && requiredRule.WithinColumns == nil {
 		return true
@@ -688,8 +687,11 @@ func (d *Detector) withinProximity(primary, required report.Finding, requiredRul
 	}
 
 	// Check column proximity (horizontal distance)
+	// Column numbers reset at each newline, so this only makes sense on the same line
 	if requiredRule.WithinColumns != nil {
-		// Use the start column of each finding for proximity calculation
+		if primary.StartLine != required.StartLine {
+			return false
+		}
 		colDiff := abs(primary.StartColumn - required.StartColumn)
 		if colDiff > *requiredRule.WithinColumns {
 			return false


### PR DESCRIPTION
## Fix #2122

The `withinProximity()` function in `detect/detect.go` was comparing column numbers
across findings on **different lines**. Since column numbers reset at each newline,
this produces meaningless proximity results.

### The bug

With `withinColumns: 5`:
- Primary finding → line 1, column 5
- Required finding → line 300, column 6

`colDiff = |5 - 6| = 1` → incorrectly satisfies `withinColumns: 5`

### The fix

Column proximity is only meaningful on the same line. Added a line-number check:
if findings are on different lines, the column constraint is not satisfiable.

Also removed a leftover debug print (`// fmt.Println(requiredRule.WithinLines)`).

Closes #2122