### PR TITLE
fix(config): detect new GitHub App installation tokens (fixes #2192)

### DIFF
--- a/cmd/generate/config/rules/github.go
+++ b/cmd/generate/config/rules/github.go
@@ -76,7 +76,7 @@ func GitHubApp() *config.Rule {
 	r := config.Rule{
 		RuleID:      "github-app-token",
 		Description: "Identified a GitHub App Token, which may compromise GitHub application integrations and source code security.",
-		Regex:       regexp.MustCompile(`(?:ghu|ghs)_[0-9a-zA-Z]{36}`),
+		Regex:       regexp.MustCompile(`(?:ghu_[0-9a-zA-Z]{36}|ghs_(?:[0-9a-zA-Z]{36}|[0-9]+_eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+))`),
 		Entropy:     3,
 		Keywords:    []string{"ghu_", "ghs_"},
 		Allowlists:  githubAllowlist,
@@ -85,9 +85,12 @@ func GitHubApp() *config.Rule {
 	// validate
 	tps := utils.GenerateSampleSecrets("github", "ghs_"+secrets.NewSecret(utils.AlphaNumeric("36")))
 	tps = append(tps, utils.GenerateSampleSecrets("github", "ghu_"+secrets.NewSecret(utils.AlphaNumeric("36")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("github", "ghs_123456_eyJ"+secrets.NewSecret(utils.AlphaNumericExtendedShort("24"))+"."+secrets.NewSecret(utils.AlphaNumericExtendedShort("160"))+"."+secrets.NewSecret(utils.AlphaNumericExtendedShort("64")))...)
 	fps := []string{
 		"ghu_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		"ghs_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"ghs_123456_not-a-jwt",
+		"ghs_not-an-app-id_eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIifQ.signature",
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2130,7 +2130,7 @@ regexes = [
 [[rules]]
 id = "github-app-token"
 description = "Identified a GitHub App Token, which may compromise GitHub application integrations and source code security."
-regex = '''(?:ghu|ghs)_[0-9a-zA-Z]{36}'''
+regex = '''(?:ghu_[0-9a-zA-Z]{36}|ghs_(?:[0-9a-zA-Z]{36}|[0-9]+_eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+))'''
 entropy = 3
 keywords = [
     "ghu_",


### PR DESCRIPTION
### Description:

Fixes #2192. GitHub App installation tokens now use `ghs_<APPID>_<JWT>` and are variable length, so the former fixed-length rule misses them. This preserves legacy `ghu_` and 36-character `ghs_` token coverage, while adding a structurally constrained matcher for the new token format: a numeric app ID plus a three-segment base64url JWT beginning with `eyJ`.

The generator includes positive samples for the new form and rejects malformed/non-numeric-app-ID examples. `config/gitleaks.toml` was regenerated from the rule source.

### Checklist:

* [x] Does your PR pass tests? `go generate ./cmd/generate/config`, `go test ./...`, and `go run . version`
* [x] Have you written new tests for your changes? Added positive and negative rule-generator validation samples.
* [x] Have you lint your code locally prior to submission? `gofmt` applied and `git diff --check` passed. `go vet ./...` currently reports two pre-existing context-cancel paths in `detect/detect_test.go`; `go test -race ./...` cannot run here because the Windows environment has no CGO C compiler.