### PR TITLE
fix: avoid running rule regex twice per matched fragment

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -449,7 +449,7 @@ func (d *Detector) detectRule(fragment Fragment, currentRaw string, r config.Rul
 
 	// use currentRaw instead of fragment.Raw since this represents the current
 	// decoding pass on the text
-	for _, matchIndex := range r.Regex.FindAllStringIndex(currentRaw, -1) {
+	for _, matchIndex := range matches {
 		// Extract secret from match
 		secret := strings.Trim(currentRaw[matchIndex[0]:matchIndex[1]], "\n")
 


### PR DESCRIPTION
## Summary
- `detectRule()` in `detect/detect.go` called `r.Regex.FindAllStringIndex(currentRaw, -1)` twice with identical arguments — once to check for an early exit, and again to drive the match loop.
- Reuses the first result instead, halving the regex work for every fragment that contains at least one match.

Fixes #2160, fixes #2121

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`