### PR TITLE
fix: global commit allowlist silently bypassed due to misscoped continue

### DIFF
--- a/sources/git.go
+++ b/sources/git.go
@@ -338,11 +338,16 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 			var commitInfo *CommitInfo
 			if gitdiffFile.PatchHeader != nil {
 				commitSHA = gitdiffFile.PatchHeader.SHA
+				var commitAllowed bool
 				for _, a := range s.Config.Allowlists {
 					if ok, c := a.CommitAllowed(gitdiffFile.PatchHeader.SHA); ok {
 						logging.Trace().Str("allowed-commit", c).Msg("skipping commit: global allowlist")
-						continue
+						commitAllowed = true
+						break
 					}
+				}
+				if commitAllowed {
+					continue
 				}
 
 				commitInfo = &CommitInfo{


### PR DESCRIPTION
## Summary
- In `sources/git.go`, the `continue` inside the `for _, a := range s.Config.Allowlists` loop only advanced to the next allowlist entry — it did not skip the outer diff-file loop.
- After the inner loop finished, `commitInfo` was built and the scanning goroutine was launched unconditionally, so commits matching a global `[[allowlists]]` `commits = [...]` entry were logged as skipped ("skipping commit: global allowlist") but scanned and reported anyway.
- Fix: track the match with a `commitAllowed` bool, `break` out of the inner loop, then `continue` the outer loop when set.

Fixes #2165

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`