### PR TITLE
docs: fix baseline typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ gitleaks will ignore any old findings that are present in the baseline. A baseli
 gitleaks git --report-path gitleaks-report.json # This will save the report in a file called gitleaks-report.json
 ```
 
-Once as baseline is created it can be applied when running the detect command again:
+Once a baseline is created it can be applied when running the detect command again:
 
 ```
 gitleaks git --baseline-path gitleaks-report.json --report-path findings.json


### PR DESCRIPTION
### Description:
Fix a small typo in the README baseline example: "Once as baseline" -> "Once a baseline".

No linked issue; this is a documentation-only typo fix.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes? Documentation-only change.
* [x] Have you lint your code locally prior to submission?

### Verification:
- `git diff --check`
