### PR TITLE
perf(detect): reuse regex matches instead of scanning the fragment twice

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -449,7 +449,7 @@ func (d *Detector) detectRule(fragment Fragment, currentRaw string, r config.Rul
 
 	// use currentRaw instead of fragment.Raw since this represents the current
 	// decoding pass on the text
-	for _, matchIndex := range r.Regex.FindAllStringIndex(currentRaw, -1) {
+	for _, matchIndex := range matches {
 		// Extract secret from match
 		secret := strings.Trim(currentRaw[matchIndex[0]:matchIndex[1]], "\n")
 


### PR DESCRIPTION
## Summary

In `detectRule` (`detect/detect.go`), the rule regex is run over `currentRaw` **twice** per fragment:

```go
matches := r.Regex.FindAllStringIndex(currentRaw, -1)   // (1) for the empty-match check
if len(matches) == 0 {
    return findings
}
...
for _, matchIndex := range r.Regex.FindAllStringIndex(currentRaw, -1) {   // (2) identical scan
```

So every fragment that has at least one match pays for two full `FindAllStringIndex` scans over the same input — the first result (`matches`) is only used for the `len == 0` early return and then thrown away.

## Fix

Iterate the already-computed `matches` slice:

```go
for _, matchIndex := range matches {
```

`matches` is not mutated anywhere between the two points, so the behavior is identical — this just removes the redundant second scan. Addresses #2121.

## Verification

- `go build ./detect/` — clean
- `go test ./detect/` — `ok` (0.6s)
- `go vet ./detect/` — no new warnings (the pre-existing test-only context-leak note is unrelated to this change)