### PR TITLE
ci: attach provenance and SBOM attestations to the published images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,5 +53,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: .
           push: true
+          provenance: mode=max
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hi, and thanks for gitleaks.

`.github/workflows/release.yml` publishes the image to both `zricethezav/gitleaks` on Docker Hub and `ghcr.io/gitleaks/gitleaks` on every release, but the pushed manifests carry no provenance or SBOM attestation.

I want to make the case for why this one is worth doing rather than just noting the gap. gitleaks is a scanner people run *inside their own CI*, over their own source, specifically to find secrets — so the container tends to be given a repository checkout and run in a job that has credentials around. That is about as much trust as a third-party image gets. Being able to verify that `zricethezav/gitleaks:latest` was built by this workflow from this repository is worth more here than it would be for most images.

The change is two lines on the build step:

```yaml
          push: true
          provenance: mode=max
          sbom: true
```

I used BuildKit's own attestations rather than a separate signing step because your single build pushes to two registries at once — BuildKit attaches the attestation to the image manifest, so Docker Hub and GHCR both get it with no extra plumbing and no second credential. It also means **no permissions change**: `contents: read` and `packages: write` stay exactly as they are, and nothing needs `id-token`.

Consumers can then verify with:

```
docker buildx imagetools inspect ghcr.io/gitleaks/gitleaks:<tag> --format '{{ json .Provenance }}'
```

Two caveats worth stating: `mode=max` records the full build including build args (`provenance: true` gives a smaller record if any have ever been sensitive), and attestations add an extra manifest to the index — Docker Hub and GHCR both support this, but it is worth knowing if a mirror sits in front.

No SLSA level claimed; the attestation is what BuildKit produces, and characterising the overall build is your call.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and both push targets myself.
